### PR TITLE
Fixed Gruntfile.js to allow build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,6 +22,10 @@ module.exports = function(grunt) {
             pattern: /\(function\s\(kiwi\)\s{/ig,
             replacement: ''
           }, {
+            pattern: /}\)\(Operator\s=\skiwi\.Operator\s\|\|\s\(kiwi\.Operator\s=\s{}\)\);/ig,
+            replacement: ''
+          }, {
+          }, {
             pattern: /}\)\(kiwi\s\|\|\s\(kiwi\s=\s{}\)\);/ig,
             replacement: ''
           }, {
@@ -54,7 +58,7 @@ module.exports = function(grunt) {
       }
     },
     exec: {
-      build: 'tsc --noImplicitAny -m commonjs -d -out lib/kiwi.js src/kiwi.ts',
+      build: 'node_modules/.bin/tsc --noImplicitAny -m amd -d -out lib/kiwi.js src/kiwi.ts',
       test: 'mocha', // --compilers ts:typescript-require' // HR: can't get internal TS modules to work with typescript-require
       bench: 'node bench/main.js'
     },


### PR DESCRIPTION
This addresses issue #3 Unable to build. It implements @Rheeseyb's two changes, and adds another one to address the failed doc generation:

- 'tsc' executable in the gruntfile was modified to 'node_modules/.bin/tsc'.
- 'commonjs' was changed to 'amd'. I don't know if there are negative consequences to that anywhere, but it seems to work in a straightforward manner with my browser app.
- added a replacement rule to address syntax that was tripping the doc generator. I just followed the convention in that part of the gruntfile.