### PR TITLE
replace tsu.AssociativeArray with an indexed map for 3.8x perf gain, smaller package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules
 tmp/
-es/
 /coverage
 lib/kiwi.min.js
 lib/kiwi.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 tmp/
+es/
 /coverage
 lib/kiwi.min.js
 lib/kiwi.d.ts

--- a/es/constraint.d.ts
+++ b/es/constraint.d.ts
@@ -1,0 +1,103 @@
+import { Expression } from "./expression";
+import { Variable } from "./variable";
+/**
+ * Kiwi is an efficient implementation of the Cassowary constraint solving
+ * algorithm, based on the seminal Cassowary paper.
+ * It is *not* a refactoring or port of the original C++ solver, but
+ * has been designed from the ground up to be lightweight and fast.
+ *
+ * **Example**
+ *
+ * ```javascript
+ * var kiwi = require('kiwi');
+ *
+ * // Create a solver
+ * var solver = new kiwi.Solver();
+ *
+ * // Create and add some editable variables
+ * var left = new kiwi.Variable();
+ * var width = new kiwi.Variable();
+ * solver.addEditVariable(left, kiwi.Strength.strong);
+ * solver.addEditVariable(width, kiwi.Strength.strong);
+ *
+ * // Create a variable calculated through a constraint
+ * var centerX = new kiwi.Variable();
+ * var expr = new kiwi.Expression([-1, centerX], left, [0.5, width]);
+ * solver.addConstraint(new kiwi.Constraint(expr, kiwi.Operator.Eq, kiwi.Strength.required));
+ *
+ * // Suggest some values to the solver
+ * solver.suggestValue(left, 0);
+ * solver.suggestValue(width, 500);
+ *
+ * // Lets solve the problem!
+ * solver.updateVariables();
+ * assert(centerX.value(), 250);
+ * ```
+ *
+ * ##API Documentation
+ * @module kiwi
+ */
+/**
+ * An enum defining the linear constraint operators.
+ *
+ * |Value|Operator|Description|
+ * |----|-----|-----|
+ * |`Le`|<=|Less than equal|
+ * |`Ge`|>=|Greater than equal|
+ * |`Eq`|==|Equal|
+ *
+ * @enum {Number}
+ */
+export declare enum Operator {
+    Le = 0,
+    Ge = 1,
+    Eq = 2
+}
+/**
+ * A linear constraint equation.
+ *
+ * A constraint equation is composed of an expression, an operator,
+ * and a strength. The RHS of the equation is implicitly zero.
+ *
+ * @class
+ * @param {Expression} expression The constraint expression (LHS).
+ * @param {Operator} operator The equation operator.
+ * @param {Expression} [rhs] Right hand side of the expression.
+ * @param {Number} [strength=Strength.required] The strength of the constraint.
+ */
+export declare class Constraint {
+    constructor(expression: Expression | Variable, operator: Operator, rhs?: Expression | Variable | number, strength?: number);
+    /**
+     * A static constraint comparison function.
+     * @private
+     */
+    static Compare(a: Constraint, b: Constraint): number;
+    /**
+     * Returns the unique id number of the constraint.
+     * @private
+     */
+    id(): number;
+    /**
+     * Returns the expression of the constraint.
+     *
+     * @return {Expression} expression
+     */
+    expression(): Expression;
+    /**
+     * Returns the relational operator of the constraint.
+     *
+     * @return {Operator} linear constraint operator
+     */
+    op(): Operator;
+    /**
+     * Returns the strength of the constraint.
+     *
+     * @return {Number} strength
+     */
+    strength(): number;
+    toString(): string;
+    private _expression;
+    private _operator;
+    private _strength;
+    private _id;
+}

--- a/es/constraint.js
+++ b/es/constraint.js
@@ -1,0 +1,137 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014, Nucleic Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|
+| The full license is in the file COPYING.txt, distributed with this software.
+|----------------------------------------------------------------------------*/
+import { Expression } from "./expression";
+import { Strength } from "./strength";
+/**
+ * Kiwi is an efficient implementation of the Cassowary constraint solving
+ * algorithm, based on the seminal Cassowary paper.
+ * It is *not* a refactoring or port of the original C++ solver, but
+ * has been designed from the ground up to be lightweight and fast.
+ *
+ * **Example**
+ *
+ * ```javascript
+ * var kiwi = require('kiwi');
+ *
+ * // Create a solver
+ * var solver = new kiwi.Solver();
+ *
+ * // Create and add some editable variables
+ * var left = new kiwi.Variable();
+ * var width = new kiwi.Variable();
+ * solver.addEditVariable(left, kiwi.Strength.strong);
+ * solver.addEditVariable(width, kiwi.Strength.strong);
+ *
+ * // Create a variable calculated through a constraint
+ * var centerX = new kiwi.Variable();
+ * var expr = new kiwi.Expression([-1, centerX], left, [0.5, width]);
+ * solver.addConstraint(new kiwi.Constraint(expr, kiwi.Operator.Eq, kiwi.Strength.required));
+ *
+ * // Suggest some values to the solver
+ * solver.suggestValue(left, 0);
+ * solver.suggestValue(width, 500);
+ *
+ * // Lets solve the problem!
+ * solver.updateVariables();
+ * assert(centerX.value(), 250);
+ * ```
+ *
+ * ##API Documentation
+ * @module kiwi
+ */
+/**
+ * An enum defining the linear constraint operators.
+ *
+ * |Value|Operator|Description|
+ * |----|-----|-----|
+ * |`Le`|<=|Less than equal|
+ * |`Ge`|>=|Greater than equal|
+ * |`Eq`|==|Equal|
+ *
+ * @enum {Number}
+ */
+export var Operator;
+(function (Operator) {
+    Operator[Operator["Le"] = 0] = "Le";
+    Operator[Operator["Ge"] = 1] = "Ge";
+    Operator[Operator["Eq"] = 2] = "Eq";
+})(Operator || (Operator = {}));
+/**
+ * A linear constraint equation.
+ *
+ * A constraint equation is composed of an expression, an operator,
+ * and a strength. The RHS of the equation is implicitly zero.
+ *
+ * @class
+ * @param {Expression} expression The constraint expression (LHS).
+ * @param {Operator} operator The equation operator.
+ * @param {Expression} [rhs] Right hand side of the expression.
+ * @param {Number} [strength=Strength.required] The strength of the constraint.
+ */
+var Constraint = /** @class */ (function () {
+    function Constraint(expression, operator, rhs, strength) {
+        if (strength === void 0) { strength = Strength.required; }
+        this._id = CnId++;
+        this._operator = operator;
+        this._strength = Strength.clip(strength);
+        if ((rhs === undefined) && (expression instanceof Expression)) {
+            this._expression = expression;
+        }
+        else {
+            this._expression = expression.minus(rhs);
+        }
+    }
+    /**
+     * A static constraint comparison function.
+     * @private
+     */
+    Constraint.Compare = function (a, b) {
+        return a.id() - b.id();
+    };
+    /**
+     * Returns the unique id number of the constraint.
+     * @private
+     */
+    Constraint.prototype.id = function () {
+        return this._id;
+    };
+    /**
+     * Returns the expression of the constraint.
+     *
+     * @return {Expression} expression
+     */
+    Constraint.prototype.expression = function () {
+        return this._expression;
+    };
+    /**
+     * Returns the relational operator of the constraint.
+     *
+     * @return {Operator} linear constraint operator
+     */
+    Constraint.prototype.op = function () {
+        return this._operator;
+    };
+    /**
+     * Returns the strength of the constraint.
+     *
+     * @return {Number} strength
+     */
+    Constraint.prototype.strength = function () {
+        return this._strength;
+    };
+    Constraint.prototype.toString = function () {
+        return this._expression.toString() + " " + ["<=", ">=", "="][this._operator] + " 0 (" + this._strength.toString() + ")";
+    };
+    return Constraint;
+}());
+export { Constraint };
+/**
+ * The internal constraint id counter.
+ * @private
+ */
+var CnId = 0;

--- a/es/expression.d.ts
+++ b/es/expression.d.ts
@@ -1,0 +1,73 @@
+import { IMap } from "./maptype";
+import { Variable } from "./variable";
+/**
+ * An expression of variable terms and a constant.
+ *
+ * The constructor accepts an arbitrary number of parameters,
+ * each of which must be one of the following types:
+ *  - number
+ *  - Variable
+ *  - Expression
+ *  - 2-tuple of [number, Variable|Expression]
+ *
+ * The parameters are summed. The tuples are multiplied.
+ *
+ * @class
+ * @param {...(number|Variable|Expression|Array)} args
+ */
+export declare class Expression {
+    constructor(...args: any[]);
+    /**
+     * Returns the mapping of terms in the expression.
+     *
+     * This *must* be treated as const.
+     * @private
+     */
+    terms(): IMap<Variable, number>;
+    /**
+     * Returns the constant of the expression.
+     * @private
+     */
+    constant(): number;
+    /**
+     * Returns the computed value of the expression.
+     *
+     * @private
+     * @return {Number} computed value of the expression
+     */
+    value(): number;
+    /**
+     * Creates a new Expression by adding a number, variable or expression
+     * to the expression.
+     *
+     * @param {Number|Variable|Expression} value Value to add.
+     * @return {Expression} expression
+     */
+    plus(value: number | Variable | Expression): Expression;
+    /**
+     * Creates a new Expression by substracting a number, variable or expression
+     * from the expression.
+     *
+     * @param {Number|Variable|Expression} value Value to substract.
+     * @return {Expression} expression
+     */
+    minus(value: number | Variable | Expression): Expression;
+    /**
+     * Creates a new Expression by multiplying with a fixed number.
+     *
+     * @param {Number} coefficient Coefficient to multiply with.
+     * @return {Expression} expression
+     */
+    multiply(coefficient: number): Expression;
+    /**
+     * Creates a new Expression by dividing with a fixed number.
+     *
+     * @param {Number} coefficient Coefficient to divide by.
+     * @return {Expression} expression
+     */
+    divide(coefficient: number): Expression;
+    isConstant(): boolean;
+    toString(): string;
+    private _terms;
+    private _constant;
+}

--- a/es/expression.js
+++ b/es/expression.js
@@ -1,0 +1,168 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014, Nucleic Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|
+| The full license is in the file COPYING.txt, distributed with this software.
+|----------------------------------------------------------------------------*/
+import { createMap } from "./maptype";
+import { Variable } from "./variable";
+/**
+ * An expression of variable terms and a constant.
+ *
+ * The constructor accepts an arbitrary number of parameters,
+ * each of which must be one of the following types:
+ *  - number
+ *  - Variable
+ *  - Expression
+ *  - 2-tuple of [number, Variable|Expression]
+ *
+ * The parameters are summed. The tuples are multiplied.
+ *
+ * @class
+ * @param {...(number|Variable|Expression|Array)} args
+ */
+var Expression = /** @class */ (function () {
+    function Expression() {
+        var parsed = parseArgs(arguments);
+        this._terms = parsed.terms;
+        this._constant = parsed.constant;
+    }
+    /**
+     * Returns the mapping of terms in the expression.
+     *
+     * This *must* be treated as const.
+     * @private
+     */
+    Expression.prototype.terms = function () {
+        return this._terms;
+    };
+    /**
+     * Returns the constant of the expression.
+     * @private
+     */
+    Expression.prototype.constant = function () {
+        return this._constant;
+    };
+    /**
+     * Returns the computed value of the expression.
+     *
+     * @private
+     * @return {Number} computed value of the expression
+     */
+    Expression.prototype.value = function () {
+        var result = this._constant;
+        for (var i = 0, n = this._terms.size(); i < n; i++) {
+            var pair = this._terms.itemAt(i);
+            result += pair.first.value() * pair.second;
+        }
+        return result;
+    };
+    /**
+     * Creates a new Expression by adding a number, variable or expression
+     * to the expression.
+     *
+     * @param {Number|Variable|Expression} value Value to add.
+     * @return {Expression} expression
+     */
+    Expression.prototype.plus = function (value) {
+        return new Expression(this, value);
+    };
+    /**
+     * Creates a new Expression by substracting a number, variable or expression
+     * from the expression.
+     *
+     * @param {Number|Variable|Expression} value Value to substract.
+     * @return {Expression} expression
+     */
+    Expression.prototype.minus = function (value) {
+        return new Expression(this, typeof value === "number" ? -value : [-1, value]);
+    };
+    /**
+     * Creates a new Expression by multiplying with a fixed number.
+     *
+     * @param {Number} coefficient Coefficient to multiply with.
+     * @return {Expression} expression
+     */
+    Expression.prototype.multiply = function (coefficient) {
+        return new Expression([coefficient, this]);
+    };
+    /**
+     * Creates a new Expression by dividing with a fixed number.
+     *
+     * @param {Number} coefficient Coefficient to divide by.
+     * @return {Expression} expression
+     */
+    Expression.prototype.divide = function (coefficient) {
+        return new Expression([1 / coefficient, this]);
+    };
+    Expression.prototype.isConstant = function () {
+        return this._terms.size() == 0;
+    };
+    Expression.prototype.toString = function () {
+        var result = this._terms._array.map(function (pair, idx) {
+            return (pair.second + "*" + pair.first.toString());
+        }).join(" + ");
+        if (!this.isConstant() && this._constant !== 0) {
+            result += " + ";
+        }
+        result += this._constant;
+        return result;
+    };
+    return Expression;
+}());
+export { Expression };
+/**
+ * An internal argument parsing function.
+ * @private
+ */
+function parseArgs(args) {
+    var constant = 0.0;
+    var factory = function () { return 0.0; };
+    var terms = createMap(Variable.Compare);
+    for (var i = 0, n = args.length; i < n; ++i) {
+        var item = args[i];
+        if (typeof item === "number") {
+            constant += item;
+        }
+        else if (item instanceof Variable) {
+            terms.setDefault(item, factory).second += 1.0;
+        }
+        else if (item instanceof Expression) {
+            constant += item.constant();
+            var terms2 = item.terms();
+            for (var j = 0, k = terms2.size(); j < k; j++) {
+                var termPair = terms2.itemAt(j);
+                terms.setDefault(termPair.first, factory).second += termPair.second;
+            }
+        }
+        else if (item instanceof Array) {
+            if (item.length !== 2) {
+                throw new Error("array must have length 2");
+            }
+            var value = item[0];
+            var value2 = item[1];
+            if (typeof value !== "number") {
+                throw new Error("array item 0 must be a number");
+            }
+            if (value2 instanceof Variable) {
+                terms.setDefault(value2, factory).second += value;
+            }
+            else if (value2 instanceof Expression) {
+                constant += (value2.constant() * value);
+                var terms2 = value2.terms();
+                for (var j = 0, k = terms2.size(); j < k; j++) {
+                    var termPair = terms2.itemAt(j);
+                    terms.setDefault(termPair.first, factory).second += (termPair.second * value);
+                }
+            }
+            else {
+                throw new Error("array item 1 must be a variable or expression");
+            }
+        }
+        else {
+            throw new Error("invalid Expression argument: " + item);
+        }
+    }
+    return { terms: terms, constant: constant };
+}

--- a/es/kiwi.d.ts
+++ b/es/kiwi.d.ts
@@ -1,0 +1,6 @@
+export * from "./constraint";
+export * from "./expression";
+export * from "./maptype";
+export * from "./solver";
+export * from "./strength";
+export * from "./variable";

--- a/es/kiwi.js
+++ b/es/kiwi.js
@@ -1,0 +1,13 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014-2018, Nucleic Development Team & H. Rutjes.
+|
+| Distributed under the terms of the Modified BSD License.
+|
+| The full license is in the file COPYING.txt, distributed with this software.
+|----------------------------------------------------------------------------*/
+export * from "./constraint";
+export * from "./expression";
+export * from "./maptype";
+export * from "./solver";
+export * from "./strength";
+export * from "./variable";

--- a/es/maptype.d.ts
+++ b/es/maptype.d.ts
@@ -1,0 +1,4 @@
+import * as tsu from "../thirdparty/tsu";
+export interface IMap<T, U> extends tsu.AssociativeArray<T, U> {
+}
+export declare function createMap<T, U>(compare: tsu.ICompare<T, T>): IMap<T, U>;

--- a/es/maptype.d.ts
+++ b/es/maptype.d.ts
@@ -1,4 +1,89 @@
-import * as tsu from "../thirdparty/tsu";
-export interface IMap<T, U> extends tsu.AssociativeArray<T, U> {
+export interface IMap<T extends {
+    id(): number;
+}, U> extends IndexedMap<T, U> {
 }
-export declare function createMap<T, U>(compare: tsu.ICompare<T, T>): IMap<T, U>;
+export declare function createMap<T extends {
+    id(): number;
+}, U>(compare: any): IMap<T, U>;
+declare class IndexedMap<T extends {
+    id(): number;
+}, U> {
+    _index: {
+        [id: number]: number;
+    };
+    _array: Pair<T, U>[];
+    /**
+     * Returns the number of items in the array.
+     */
+    size(): number;
+    /**
+    * Returns true if the array is empty.
+    */
+    empty(): boolean;
+    /**
+     * Returns the item at the given array index.
+     *
+     * @param index The integer index of the desired item.
+     */
+    itemAt(index: number): Pair<T, U>;
+    /**
+    * Returns true if the key is in the array, false otherwise.
+    *
+    * @param key The key to locate in the array.
+    */
+    contains(key: T): boolean;
+    /**
+     * Returns the pair associated with the given key, or undefined.
+     *
+     * @param key The key to locate in the array.
+     */
+    find(key: T): Pair<T, U>;
+    /**
+     * Returns the pair associated with the key if it exists.
+     *
+     * If the key does not exist, a new pair will be created and
+     * inserted using the value created by the given factory.
+     *
+     * @param key The key to locate in the array.
+     * @param factory The function which creates the default value.
+     */
+    setDefault(key: T, factory: () => U): Pair<T, U>;
+    /**
+     * Insert the pair into the array and return the pair.
+     *
+     * This will overwrite any existing entry in the array.
+     *
+     * @param key The key portion of the pair.
+     * @param value The value portion of the pair.
+     */
+    insert(key: T, value: U): Pair<T, U>;
+    /**
+     * Removes and returns the pair for the given key, or undefined.
+     *
+     * @param key The key to remove from the map.
+     */
+    erase(key: T): Pair<T, U>;
+    /**
+     * Create a copy of this associative array.
+     */
+    copy(): IndexedMap<T, U>;
+}
+/**
+* A class which defines a generic pair object.
+*/
+declare class Pair<T, U> {
+    first: T;
+    second: U;
+    /**
+    * Construct a new Pair object.
+    *
+    * @param first The first item of the pair.
+    * @param second The second item of the pair.
+    */
+    constructor(first: T, second: U);
+    /**
+    * Create a copy of the pair.
+    */
+    copy(): Pair<T, U>;
+}
+export {};

--- a/es/maptype.js
+++ b/es/maptype.js
@@ -1,0 +1,11 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014, Nucleic Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|
+| The full license is in the file COPYING.txt, distributed with this software.
+|----------------------------------------------------------------------------*/
+import * as tsu from "../thirdparty/tsu";
+export function createMap(compare) {
+    return new tsu.AssociativeArray(compare);
+}

--- a/es/maptype.js
+++ b/es/maptype.js
@@ -5,7 +5,147 @@
 |
 | The full license is in the file COPYING.txt, distributed with this software.
 |----------------------------------------------------------------------------*/
-import * as tsu from "../thirdparty/tsu";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
 export function createMap(compare) {
-    return new tsu.AssociativeArray(compare);
+    return new IndexedMap();
 }
+var IndexedMap = /** @class */ (function () {
+    function IndexedMap() {
+        this._index = {};
+        this._array = [];
+    }
+    /**
+     * Returns the number of items in the array.
+     */
+    IndexedMap.prototype.size = function () {
+        return this._array.length;
+    };
+    /**
+    * Returns true if the array is empty.
+    */
+    IndexedMap.prototype.empty = function () {
+        return this._array.length === 0;
+    };
+    /**
+     * Returns the item at the given array index.
+     *
+     * @param index The integer index of the desired item.
+     */
+    IndexedMap.prototype.itemAt = function (index) {
+        return this._array[index];
+    };
+    /**
+    * Returns true if the key is in the array, false otherwise.
+    *
+    * @param key The key to locate in the array.
+    */
+    IndexedMap.prototype.contains = function (key) {
+        return this._index[key.id()] !== undefined;
+    };
+    /**
+     * Returns the pair associated with the given key, or undefined.
+     *
+     * @param key The key to locate in the array.
+     */
+    IndexedMap.prototype.find = function (key) {
+        var i = this._index[key.id()];
+        return i === undefined ? undefined : this._array[i];
+    };
+    /**
+     * Returns the pair associated with the key if it exists.
+     *
+     * If the key does not exist, a new pair will be created and
+     * inserted using the value created by the given factory.
+     *
+     * @param key The key to locate in the array.
+     * @param factory The function which creates the default value.
+     */
+    IndexedMap.prototype.setDefault = function (key, factory) {
+        var i = this._index[key.id()];
+        if (i === undefined) {
+            var pair = new Pair(key, factory());
+            this._index[key.id()] = this._array.length;
+            this._array.push(pair);
+            return pair;
+        }
+        else {
+            return this._array[i];
+        }
+    };
+    /**
+     * Insert the pair into the array and return the pair.
+     *
+     * This will overwrite any existing entry in the array.
+     *
+     * @param key The key portion of the pair.
+     * @param value The value portion of the pair.
+     */
+    IndexedMap.prototype.insert = function (key, value) {
+        var pair = new Pair(key, value), i = this._index[key.id()];
+        if (i === undefined) {
+            this._index[key.id()] = this._array.length;
+            this._array.push(pair);
+        }
+        else {
+            this._array[i] = pair;
+        }
+        return pair;
+    };
+    /**
+     * Removes and returns the pair for the given key, or undefined.
+     *
+     * @param key The key to remove from the map.
+     */
+    IndexedMap.prototype.erase = function (key) {
+        var i = this._index[key.id()];
+        if (i === undefined)
+            return undefined;
+        this._index[key.id()] = undefined;
+        var pair = this._array[i], last = this._array.pop();
+        if (pair !== last) {
+            this._array[i] = last;
+            this._index[last.first.id()] = i;
+        }
+        return pair;
+    };
+    /**
+     * Create a copy of this associative array.
+     */
+    IndexedMap.prototype.copy = function () {
+        var copy = new IndexedMap();
+        copy._index = __assign({}, this._index);
+        copy._array = this._array.map(function (p) { return p.copy(); });
+        return copy;
+    };
+    return IndexedMap;
+}());
+/**
+* A class which defines a generic pair object.
+*/
+var Pair = /** @class */ (function () {
+    /**
+    * Construct a new Pair object.
+    *
+    * @param first The first item of the pair.
+    * @param second The second item of the pair.
+    */
+    function Pair(first, second) {
+        this.first = first;
+        this.second = second;
+    }
+    /**
+    * Create a copy of the pair.
+    */
+    Pair.prototype.copy = function () { return new Pair(this.first, this.second); };
+    return Pair;
+}());

--- a/es/solver.d.ts
+++ b/es/solver.d.ts
@@ -1,0 +1,242 @@
+import { Constraint, Operator } from "./constraint";
+import { Expression } from "./expression";
+import { Variable } from "./variable";
+/**
+ * The constraint solver class.
+ *
+ * @class
+ */
+export declare class Solver {
+    /**
+     * Construct a new Solver.
+     */
+    constructor();
+    /**
+     * Creates and add a constraint to the solver.
+     *
+     * @param {Expression|Variable} lhs Left hand side of the expression
+     * @param {Operator} operator Operator
+     * @param {Expression|Variable|Number} rhs Right hand side of the expression
+     * @param {Number} [strength=Strength.required] Strength
+     */
+    createConstraint(lhs: Expression | Variable, operator: Operator, rhs: Expression | Variable | number, strength?: number): Constraint;
+    /**
+     * Add a constraint to the solver.
+     *
+     * @param {Constraint} constraint Constraint to add to the solver
+     */
+    addConstraint(constraint: Constraint): void;
+    /**
+     * Remove a constraint from the solver.
+     *
+     * @param {Constraint} constraint Constraint to remove from the solver
+     */
+    removeConstraint(constraint: Constraint): void;
+    /**
+     * Test whether the solver contains the constraint.
+     *
+     * @param {Constraint} constraint Constraint to test for
+     * @return {Bool} true or false
+     */
+    hasConstraint(constraint: Constraint): boolean;
+    /**
+     * Add an edit variable to the solver.
+     *
+     * @param {Variable} variable Edit variable to add to the solver
+     * @param {Number} strength Strength, should be less than `Strength.required`
+     */
+    addEditVariable(variable: Variable, strength: number): void;
+    /**
+     * Remove an edit variable from the solver.
+     *
+     * @param {Variable} variable Edit variable to remove from the solver
+     */
+    removeEditVariable(variable: Variable): void;
+    /**
+     * Test whether the solver contains the edit variable.
+     *
+     * @param {Variable} variable Edit variable to test for
+     * @return {Bool} true or false
+     */
+    hasEditVariable(variable: Variable): boolean;
+    /**
+     * Suggest the value of an edit variable.
+     *
+     * @param {Variable} variable Edit variable to suggest a value for
+     * @param {Number} value Suggested value
+     */
+    suggestValue(variable: Variable, value: number): void;
+    /**
+     * Update the values of the variables.
+     */
+    updateVariables(): void;
+    /**
+     * Get the symbol for the given variable.
+     *
+     * If a symbol does not exist for the variable, one will be created.
+     * @private
+     */
+    private _getVarSymbol;
+    /**
+     * Create a new Row object for the given constraint.
+     *
+     * The terms in the constraint will be converted to cells in the row.
+     * Any term in the constraint with a coefficient of zero is ignored.
+     * This method uses the `_getVarSymbol` method to get the symbol for
+     * the variables added to the row. If the symbol for a given cell
+     * variable is basic, the cell variable will be substituted with the
+     * basic row.
+     *
+     * The necessary slack and error variables will be added to the row.
+     * If the constant for the row is negative, the sign for the row
+     * will be inverted so the constant becomes positive.
+     *
+     * Returns the created Row and the tag for tracking the constraint.
+     * @private
+     */
+    private _createRow;
+    /**
+     * Choose the subject for solving for the row.
+     *
+     * This method will choose the best subject for using as the solve
+     * target for the row. An invalid symbol will be returned if there
+     * is no valid target.
+     *
+     * The symbols are chosen according to the following precedence:
+     *
+     * 1) The first symbol representing an external variable.
+     * 2) A negative slack or error tag variable.
+     *
+     * If a subject cannot be found, an invalid symbol will be returned.
+     *
+     * @private
+     */
+    private _chooseSubject;
+    /**
+     * Add the row to the tableau using an artificial variable.
+     *
+     * This will return false if the constraint cannot be satisfied.
+     *
+     * @private
+     */
+    private _addWithArtificialVariable;
+    /**
+     * Substitute the parametric symbol with the given row.
+     *
+     * This method will substitute all instances of the parametric symbol
+     * in the tableau and the objective function with the given row.
+     *
+     * @private
+     */
+    private _substitute;
+    /**
+     * Optimize the system for the given objective function.
+     *
+     * This method performs iterations of Phase 2 of the simplex method
+     * until the objective function reaches a minimum.
+     *
+     * @private
+     */
+    private _optimize;
+    /**
+     * Optimize the system using the dual of the simplex method.
+     *
+     * The current state of the system should be such that the objective
+     * function is optimal, but not feasible. This method will perform
+     * an iteration of the dual simplex method to make the solution both
+     * optimal and feasible.
+     *
+     * @private
+     */
+    private _dualOptimize;
+    /**
+     * Compute the entering variable for a pivot operation.
+     *
+     * This method will return first symbol in the objective function which
+     * is non-dummy and has a coefficient less than zero. If no symbol meets
+     * the criteria, it means the objective function is at a minimum, and an
+     * invalid symbol is returned.
+     *
+     * @private
+     */
+    private _getEnteringSymbol;
+    /**
+     * Compute the entering symbol for the dual optimize operation.
+     *
+     * This method will return the symbol in the row which has a positive
+     * coefficient and yields the minimum ratio for its respective symbol
+     * in the objective function. The provided row *must* be infeasible.
+     * If no symbol is found which meats the criteria, an invalid symbol
+     * is returned.
+     *
+     * @private
+     */
+    private _getDualEnteringSymbol;
+    /**
+     * Compute the symbol for pivot exit row.
+     *
+     * This method will return the symbol for the exit row in the row
+     * map. If no appropriate exit symbol is found, an invalid symbol
+     * will be returned. This indicates that the objective function is
+     * unbounded.
+     *
+     * @private
+     */
+    private _getLeavingSymbol;
+    /**
+     * Compute the leaving symbol for a marker variable.
+     *
+     * This method will return a symbol corresponding to a basic row
+     * which holds the given marker variable. The row will be chosen
+     * according to the following precedence:
+     *
+     * 1) The row with a restricted basic varible and a negative coefficient
+     *    for the marker with the smallest ratio of -constant / coefficient.
+     *
+     * 2) The row with a restricted basic variable and the smallest ratio
+     *    of constant / coefficient.
+     *
+     * 3) The last unrestricted row which contains the marker.
+     *
+     * If the marker does not exist in any row, an invalid symbol will be
+     * returned. This indicates an internal solver error since the marker
+     * *should* exist somewhere in the tableau.
+     *
+     * @private
+     */
+    private _getMarkerLeavingSymbol;
+    /**
+     * Remove the effects of a constraint on the objective function.
+     *
+     * @private
+     */
+    private _removeConstraintEffects;
+    /**
+     * Remove the effects of an error marker on the objective function.
+     *
+     * @private
+     */
+    private _removeMarkerEffects;
+    /**
+     * Get the first Slack or Error symbol in the row.
+     *
+     * If no such symbol is present, an invalid symbol will be returned.
+     *
+     * @private
+     */
+    private _anyPivotableSymbol;
+    /**
+     * Returns a new Symbol of the given type.
+     *
+     * @private
+     */
+    private _makeSymbol;
+    private _cnMap;
+    private _rowMap;
+    private _varMap;
+    private _editMap;
+    private _infeasibleRows;
+    private _objective;
+    private _artificial;
+    private _idTick;
+}

--- a/es/solver.js
+++ b/es/solver.js
@@ -1,0 +1,954 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014, Nucleic Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|
+| The full license is in the file COPYING.txt, distributed with this software.
+|----------------------------------------------------------------------------*/
+import { Constraint, Operator } from "./constraint";
+import { Expression } from "./expression";
+import { createMap } from "./maptype";
+import { Strength } from "./strength";
+import { Variable } from "./variable";
+/**
+ * The constraint solver class.
+ *
+ * @class
+ */
+var Solver = /** @class */ (function () {
+    /**
+     * Construct a new Solver.
+     */
+    function Solver() {
+        this._cnMap = createCnMap();
+        this._rowMap = createRowMap();
+        this._varMap = createVarMap();
+        this._editMap = createEditMap();
+        this._infeasibleRows = [];
+        this._objective = new Row();
+        this._artificial = null;
+        this._idTick = 0;
+    }
+    /**
+     * Creates and add a constraint to the solver.
+     *
+     * @param {Expression|Variable} lhs Left hand side of the expression
+     * @param {Operator} operator Operator
+     * @param {Expression|Variable|Number} rhs Right hand side of the expression
+     * @param {Number} [strength=Strength.required] Strength
+     */
+    Solver.prototype.createConstraint = function (lhs, operator, rhs, strength) {
+        if (strength === void 0) { strength = Strength.required; }
+        var cn = new Constraint(lhs, operator, rhs, strength);
+        this.addConstraint(cn);
+        return cn;
+    };
+    /**
+     * Add a constraint to the solver.
+     *
+     * @param {Constraint} constraint Constraint to add to the solver
+     */
+    Solver.prototype.addConstraint = function (constraint) {
+        var cnPair = this._cnMap.find(constraint);
+        if (cnPair !== undefined) {
+            throw new Error("duplicate constraint");
+        }
+        // Creating a row causes symbols to be reserved for the variables
+        // in the constraint. If this method exits with an exception,
+        // then its possible those variables will linger in the var map.
+        // Since its likely that those variables will be used in other
+        // constraints and since exceptional conditions are uncommon,
+        // i'm not too worried about aggressive cleanup of the var map.
+        var data = this._createRow(constraint);
+        var row = data.row;
+        var tag = data.tag;
+        var subject = this._chooseSubject(row, tag);
+        // If chooseSubject couldnt find a valid entering symbol, one
+        // last option is available if the entire row is composed of
+        // dummy variables. If the constant of the row is zero, then
+        // this represents redundant constraints and the new dummy
+        // marker can enter the basis. If the constant is non-zero,
+        // then it represents an unsatisfiable constraint.
+        if (subject.type() === SymbolType.Invalid && row.allDummies()) {
+            if (!nearZero(row.constant())) {
+                throw new Error("unsatisfiable constraint");
+            }
+            else {
+                subject = tag.marker;
+            }
+        }
+        // If an entering symbol still isn't found, then the row must
+        // be added using an artificial variable. If that fails, then
+        // the row represents an unsatisfiable constraint.
+        if (subject.type() === SymbolType.Invalid) {
+            if (!this._addWithArtificialVariable(row)) {
+                throw new Error("unsatisfiable constraint");
+            }
+        }
+        else {
+            row.solveFor(subject);
+            this._substitute(subject, row);
+            this._rowMap.insert(subject, row);
+        }
+        this._cnMap.insert(constraint, tag);
+        // Optimizing after each constraint is added performs less
+        // aggregate work due to a smaller average system size. It
+        // also ensures the solver remains in a consistent state.
+        this._optimize(this._objective);
+    };
+    /**
+     * Remove a constraint from the solver.
+     *
+     * @param {Constraint} constraint Constraint to remove from the solver
+     */
+    Solver.prototype.removeConstraint = function (constraint) {
+        var cnPair = this._cnMap.erase(constraint);
+        if (cnPair === undefined) {
+            throw new Error("unknown constraint");
+        }
+        // Remove the error effects from the objective function
+        // *before* pivoting, or substitutions into the objective
+        // will lead to incorrect solver results.
+        this._removeConstraintEffects(constraint, cnPair.second);
+        // If the marker is basic, simply drop the row. Otherwise,
+        // pivot the marker into the basis and then drop the row.
+        var marker = cnPair.second.marker;
+        var rowPair = this._rowMap.erase(marker);
+        if (rowPair === undefined) {
+            var leaving = this._getMarkerLeavingSymbol(marker);
+            if (leaving.type() === SymbolType.Invalid) {
+                throw new Error("failed to find leaving row");
+            }
+            rowPair = this._rowMap.erase(leaving);
+            rowPair.second.solveForEx(leaving, marker);
+            this._substitute(marker, rowPair.second);
+        }
+        // Optimizing after each constraint is removed ensures that the
+        // solver remains consistent. It makes the solver api easier to
+        // use at a small tradeoff for speed.
+        this._optimize(this._objective);
+    };
+    /**
+     * Test whether the solver contains the constraint.
+     *
+     * @param {Constraint} constraint Constraint to test for
+     * @return {Bool} true or false
+     */
+    Solver.prototype.hasConstraint = function (constraint) {
+        return this._cnMap.contains(constraint);
+    };
+    /**
+     * Add an edit variable to the solver.
+     *
+     * @param {Variable} variable Edit variable to add to the solver
+     * @param {Number} strength Strength, should be less than `Strength.required`
+     */
+    Solver.prototype.addEditVariable = function (variable, strength) {
+        var editPair = this._editMap.find(variable);
+        if (editPair !== undefined) {
+            throw new Error("duplicate edit variable");
+        }
+        strength = Strength.clip(strength);
+        if (strength === Strength.required) {
+            throw new Error("bad required strength");
+        }
+        var expr = new Expression(variable);
+        var cn = new Constraint(expr, Operator.Eq, undefined, strength);
+        this.addConstraint(cn);
+        var tag = this._cnMap.find(cn).second;
+        var info = { tag: tag, constraint: cn, constant: 0.0 };
+        this._editMap.insert(variable, info);
+    };
+    /**
+     * Remove an edit variable from the solver.
+     *
+     * @param {Variable} variable Edit variable to remove from the solver
+     */
+    Solver.prototype.removeEditVariable = function (variable) {
+        var editPair = this._editMap.erase(variable);
+        if (editPair === undefined) {
+            throw new Error("unknown edit variable");
+        }
+        this.removeConstraint(editPair.second.constraint);
+    };
+    /**
+     * Test whether the solver contains the edit variable.
+     *
+     * @param {Variable} variable Edit variable to test for
+     * @return {Bool} true or false
+     */
+    Solver.prototype.hasEditVariable = function (variable) {
+        return this._editMap.contains(variable);
+    };
+    /**
+     * Suggest the value of an edit variable.
+     *
+     * @param {Variable} variable Edit variable to suggest a value for
+     * @param {Number} value Suggested value
+     */
+    Solver.prototype.suggestValue = function (variable, value) {
+        var editPair = this._editMap.find(variable);
+        if (editPair === undefined) {
+            throw new Error("unknown edit variable");
+        }
+        var rows = this._rowMap;
+        var info = editPair.second;
+        var delta = value - info.constant;
+        info.constant = value;
+        // Check first if the positive error variable is basic.
+        var marker = info.tag.marker;
+        var rowPair = rows.find(marker);
+        if (rowPair !== undefined) {
+            if (rowPair.second.add(-delta) < 0.0) {
+                this._infeasibleRows.push(marker);
+            }
+            this._dualOptimize();
+            return;
+        }
+        // Check next if the negative error variable is basic.
+        var other = info.tag.other;
+        rowPair = rows.find(other);
+        if (rowPair !== undefined) {
+            if (rowPair.second.add(delta) < 0.0) {
+                this._infeasibleRows.push(other);
+            }
+            this._dualOptimize();
+            return;
+        }
+        // Otherwise update each row where the error variables exist.
+        for (var i = 0, n = rows.size(); i < n; ++i) {
+            var rowPair_1 = rows.itemAt(i);
+            var row = rowPair_1.second;
+            var coeff = row.coefficientFor(marker);
+            if (coeff !== 0.0 && row.add(delta * coeff) < 0.0 &&
+                rowPair_1.first.type() !== SymbolType.External) {
+                this._infeasibleRows.push(rowPair_1.first);
+            }
+        }
+        this._dualOptimize();
+    };
+    /**
+     * Update the values of the variables.
+     */
+    Solver.prototype.updateVariables = function () {
+        var vars = this._varMap;
+        var rows = this._rowMap;
+        for (var i = 0, n = vars.size(); i < n; ++i) {
+            var pair = vars.itemAt(i);
+            var rowPair = rows.find(pair.second);
+            if (rowPair !== undefined) {
+                pair.first.setValue(rowPair.second.constant());
+            }
+            else {
+                pair.first.setValue(0.0);
+            }
+        }
+    };
+    /**
+     * Get the symbol for the given variable.
+     *
+     * If a symbol does not exist for the variable, one will be created.
+     * @private
+     */
+    Solver.prototype._getVarSymbol = function (variable) {
+        var _this = this;
+        var factory = function () { return _this._makeSymbol(SymbolType.External); };
+        return this._varMap.setDefault(variable, factory).second;
+    };
+    /**
+     * Create a new Row object for the given constraint.
+     *
+     * The terms in the constraint will be converted to cells in the row.
+     * Any term in the constraint with a coefficient of zero is ignored.
+     * This method uses the `_getVarSymbol` method to get the symbol for
+     * the variables added to the row. If the symbol for a given cell
+     * variable is basic, the cell variable will be substituted with the
+     * basic row.
+     *
+     * The necessary slack and error variables will be added to the row.
+     * If the constant for the row is negative, the sign for the row
+     * will be inverted so the constant becomes positive.
+     *
+     * Returns the created Row and the tag for tracking the constraint.
+     * @private
+     */
+    Solver.prototype._createRow = function (constraint) {
+        var expr = constraint.expression();
+        var row = new Row(expr.constant());
+        // Substitute the current basic variables into the row.
+        var terms = expr.terms();
+        for (var i = 0, n = terms.size(); i < n; ++i) {
+            var termPair = terms.itemAt(i);
+            if (!nearZero(termPair.second)) {
+                var symbol = this._getVarSymbol(termPair.first);
+                var basicPair = this._rowMap.find(symbol);
+                if (basicPair !== undefined) {
+                    row.insertRow(basicPair.second, termPair.second);
+                }
+                else {
+                    row.insertSymbol(symbol, termPair.second);
+                }
+            }
+        }
+        // Add the necessary slack, error, and dummy variables.
+        var objective = this._objective;
+        var strength = constraint.strength();
+        var tag = { marker: INVALID_SYMBOL, other: INVALID_SYMBOL };
+        switch (constraint.op()) {
+            case Operator.Le:
+            case Operator.Ge:
+                {
+                    var coeff = constraint.op() === Operator.Le ? 1.0 : -1.0;
+                    var slack = this._makeSymbol(SymbolType.Slack);
+                    tag.marker = slack;
+                    row.insertSymbol(slack, coeff);
+                    if (strength < Strength.required) {
+                        var error = this._makeSymbol(SymbolType.Error);
+                        tag.other = error;
+                        row.insertSymbol(error, -coeff);
+                        objective.insertSymbol(error, strength);
+                    }
+                    break;
+                }
+            case Operator.Eq:
+                {
+                    if (strength < Strength.required) {
+                        var errplus = this._makeSymbol(SymbolType.Error);
+                        var errminus = this._makeSymbol(SymbolType.Error);
+                        tag.marker = errplus;
+                        tag.other = errminus;
+                        row.insertSymbol(errplus, -1.0); // v = eplus - eminus
+                        row.insertSymbol(errminus, 1.0); // v - eplus + eminus = 0
+                        objective.insertSymbol(errplus, strength);
+                        objective.insertSymbol(errminus, strength);
+                    }
+                    else {
+                        var dummy = this._makeSymbol(SymbolType.Dummy);
+                        tag.marker = dummy;
+                        row.insertSymbol(dummy);
+                    }
+                    break;
+                }
+        }
+        // Ensure the row has a positive constant.
+        if (row.constant() < 0.0) {
+            row.reverseSign();
+        }
+        return { row: row, tag: tag };
+    };
+    /**
+     * Choose the subject for solving for the row.
+     *
+     * This method will choose the best subject for using as the solve
+     * target for the row. An invalid symbol will be returned if there
+     * is no valid target.
+     *
+     * The symbols are chosen according to the following precedence:
+     *
+     * 1) The first symbol representing an external variable.
+     * 2) A negative slack or error tag variable.
+     *
+     * If a subject cannot be found, an invalid symbol will be returned.
+     *
+     * @private
+     */
+    Solver.prototype._chooseSubject = function (row, tag) {
+        var cells = row.cells();
+        for (var i = 0, n = cells.size(); i < n; ++i) {
+            var pair = cells.itemAt(i);
+            if (pair.first.type() === SymbolType.External) {
+                return pair.first;
+            }
+        }
+        var type = tag.marker.type();
+        if (type === SymbolType.Slack || type === SymbolType.Error) {
+            if (row.coefficientFor(tag.marker) < 0.0) {
+                return tag.marker;
+            }
+        }
+        type = tag.other.type();
+        if (type === SymbolType.Slack || type === SymbolType.Error) {
+            if (row.coefficientFor(tag.other) < 0.0) {
+                return tag.other;
+            }
+        }
+        return INVALID_SYMBOL;
+    };
+    /**
+     * Add the row to the tableau using an artificial variable.
+     *
+     * This will return false if the constraint cannot be satisfied.
+     *
+     * @private
+     */
+    Solver.prototype._addWithArtificialVariable = function (row) {
+        // Create and add the artificial variable to the tableau.
+        var art = this._makeSymbol(SymbolType.Slack);
+        this._rowMap.insert(art, row.copy());
+        this._artificial = row.copy();
+        // Optimize the artificial objective. This is successful
+        // only if the artificial objective is optimized to zero.
+        this._optimize(this._artificial);
+        var success = nearZero(this._artificial.constant());
+        this._artificial = null;
+        // If the artificial variable is basic, pivot the row so that
+        // it becomes non-basic. If the row is constant, exit early.
+        var pair = this._rowMap.erase(art);
+        if (pair !== undefined) {
+            var basicRow = pair.second;
+            if (basicRow.isConstant()) {
+                return success;
+            }
+            var entering = this._anyPivotableSymbol(basicRow);
+            if (entering.type() === SymbolType.Invalid) {
+                return false; // unsatisfiable (will this ever happen?)
+            }
+            basicRow.solveForEx(art, entering);
+            this._substitute(entering, basicRow);
+            this._rowMap.insert(entering, basicRow);
+        }
+        // Remove the artificial variable from the tableau.
+        var rows = this._rowMap;
+        for (var i = 0, n = rows.size(); i < n; ++i) {
+            rows.itemAt(i).second.removeSymbol(art);
+        }
+        this._objective.removeSymbol(art);
+        return success;
+    };
+    /**
+     * Substitute the parametric symbol with the given row.
+     *
+     * This method will substitute all instances of the parametric symbol
+     * in the tableau and the objective function with the given row.
+     *
+     * @private
+     */
+    Solver.prototype._substitute = function (symbol, row) {
+        var rows = this._rowMap;
+        for (var i = 0, n = rows.size(); i < n; ++i) {
+            var pair = rows.itemAt(i);
+            pair.second.substitute(symbol, row);
+            if (pair.second.constant() < 0.0 &&
+                pair.first.type() !== SymbolType.External) {
+                this._infeasibleRows.push(pair.first);
+            }
+        }
+        this._objective.substitute(symbol, row);
+        if (this._artificial) {
+            this._artificial.substitute(symbol, row);
+        }
+    };
+    /**
+     * Optimize the system for the given objective function.
+     *
+     * This method performs iterations of Phase 2 of the simplex method
+     * until the objective function reaches a minimum.
+     *
+     * @private
+     */
+    Solver.prototype._optimize = function (objective) {
+        while (true) {
+            var entering = this._getEnteringSymbol(objective);
+            if (entering.type() === SymbolType.Invalid) {
+                return;
+            }
+            var leaving = this._getLeavingSymbol(entering);
+            if (leaving.type() === SymbolType.Invalid) {
+                throw new Error("the objective is unbounded");
+            }
+            // pivot the entering symbol into the basis
+            var row = this._rowMap.erase(leaving).second;
+            row.solveForEx(leaving, entering);
+            this._substitute(entering, row);
+            this._rowMap.insert(entering, row);
+        }
+    };
+    /**
+     * Optimize the system using the dual of the simplex method.
+     *
+     * The current state of the system should be such that the objective
+     * function is optimal, but not feasible. This method will perform
+     * an iteration of the dual simplex method to make the solution both
+     * optimal and feasible.
+     *
+     * @private
+     */
+    Solver.prototype._dualOptimize = function () {
+        var rows = this._rowMap;
+        var infeasible = this._infeasibleRows;
+        while (infeasible.length !== 0) {
+            var leaving = infeasible.pop();
+            var pair = rows.find(leaving);
+            if (pair !== undefined && pair.second.constant() < 0.0) {
+                var entering = this._getDualEnteringSymbol(pair.second);
+                if (entering.type() === SymbolType.Invalid) {
+                    throw new Error("dual optimize failed");
+                }
+                // pivot the entering symbol into the basis
+                var row = pair.second;
+                rows.erase(leaving);
+                row.solveForEx(leaving, entering);
+                this._substitute(entering, row);
+                rows.insert(entering, row);
+            }
+        }
+    };
+    /**
+     * Compute the entering variable for a pivot operation.
+     *
+     * This method will return first symbol in the objective function which
+     * is non-dummy and has a coefficient less than zero. If no symbol meets
+     * the criteria, it means the objective function is at a minimum, and an
+     * invalid symbol is returned.
+     *
+     * @private
+     */
+    Solver.prototype._getEnteringSymbol = function (objective) {
+        var cells = objective.cells();
+        for (var i = 0, n = cells.size(); i < n; ++i) {
+            var pair = cells.itemAt(i);
+            var symbol = pair.first;
+            if (pair.second < 0.0 && symbol.type() !== SymbolType.Dummy) {
+                return symbol;
+            }
+        }
+        return INVALID_SYMBOL;
+    };
+    /**
+     * Compute the entering symbol for the dual optimize operation.
+     *
+     * This method will return the symbol in the row which has a positive
+     * coefficient and yields the minimum ratio for its respective symbol
+     * in the objective function. The provided row *must* be infeasible.
+     * If no symbol is found which meats the criteria, an invalid symbol
+     * is returned.
+     *
+     * @private
+     */
+    Solver.prototype._getDualEnteringSymbol = function (row) {
+        var ratio = Number.MAX_VALUE;
+        var entering = INVALID_SYMBOL;
+        var cells = row.cells();
+        for (var i = 0, n = cells.size(); i < n; ++i) {
+            var pair = cells.itemAt(i);
+            var symbol = pair.first;
+            var c = pair.second;
+            if (c > 0.0 && symbol.type() !== SymbolType.Dummy) {
+                var coeff = this._objective.coefficientFor(symbol);
+                var r = coeff / c;
+                if (r < ratio) {
+                    ratio = r;
+                    entering = symbol;
+                }
+            }
+        }
+        return entering;
+    };
+    /**
+     * Compute the symbol for pivot exit row.
+     *
+     * This method will return the symbol for the exit row in the row
+     * map. If no appropriate exit symbol is found, an invalid symbol
+     * will be returned. This indicates that the objective function is
+     * unbounded.
+     *
+     * @private
+     */
+    Solver.prototype._getLeavingSymbol = function (entering) {
+        var ratio = Number.MAX_VALUE;
+        var found = INVALID_SYMBOL;
+        var rows = this._rowMap;
+        for (var i = 0, n = rows.size(); i < n; ++i) {
+            var pair = rows.itemAt(i);
+            var symbol = pair.first;
+            if (symbol.type() !== SymbolType.External) {
+                var row = pair.second;
+                var temp = row.coefficientFor(entering);
+                if (temp < 0.0) {
+                    var temp_ratio = -row.constant() / temp;
+                    if (temp_ratio < ratio) {
+                        ratio = temp_ratio;
+                        found = symbol;
+                    }
+                }
+            }
+        }
+        return found;
+    };
+    /**
+     * Compute the leaving symbol for a marker variable.
+     *
+     * This method will return a symbol corresponding to a basic row
+     * which holds the given marker variable. The row will be chosen
+     * according to the following precedence:
+     *
+     * 1) The row with a restricted basic varible and a negative coefficient
+     *    for the marker with the smallest ratio of -constant / coefficient.
+     *
+     * 2) The row with a restricted basic variable and the smallest ratio
+     *    of constant / coefficient.
+     *
+     * 3) The last unrestricted row which contains the marker.
+     *
+     * If the marker does not exist in any row, an invalid symbol will be
+     * returned. This indicates an internal solver error since the marker
+     * *should* exist somewhere in the tableau.
+     *
+     * @private
+     */
+    Solver.prototype._getMarkerLeavingSymbol = function (marker) {
+        var dmax = Number.MAX_VALUE;
+        var r1 = dmax;
+        var r2 = dmax;
+        var invalid = INVALID_SYMBOL;
+        var first = invalid;
+        var second = invalid;
+        var third = invalid;
+        var rows = this._rowMap;
+        for (var i = 0, n = rows.size(); i < n; ++i) {
+            var pair = rows.itemAt(i);
+            var row = pair.second;
+            var c = row.coefficientFor(marker);
+            if (c === 0.0) {
+                continue;
+            }
+            var symbol = pair.first;
+            if (symbol.type() === SymbolType.External) {
+                third = symbol;
+            }
+            else if (c < 0.0) {
+                var r = -row.constant() / c;
+                if (r < r1) {
+                    r1 = r;
+                    first = symbol;
+                }
+            }
+            else {
+                var r = row.constant() / c;
+                if (r < r2) {
+                    r2 = r;
+                    second = symbol;
+                }
+            }
+        }
+        if (first !== invalid) {
+            return first;
+        }
+        if (second !== invalid) {
+            return second;
+        }
+        return third;
+    };
+    /**
+     * Remove the effects of a constraint on the objective function.
+     *
+     * @private
+     */
+    Solver.prototype._removeConstraintEffects = function (cn, tag) {
+        if (tag.marker.type() === SymbolType.Error) {
+            this._removeMarkerEffects(tag.marker, cn.strength());
+        }
+        if (tag.other.type() === SymbolType.Error) {
+            this._removeMarkerEffects(tag.other, cn.strength());
+        }
+    };
+    /**
+     * Remove the effects of an error marker on the objective function.
+     *
+     * @private
+     */
+    Solver.prototype._removeMarkerEffects = function (marker, strength) {
+        var pair = this._rowMap.find(marker);
+        if (pair !== undefined) {
+            this._objective.insertRow(pair.second, -strength);
+        }
+        else {
+            this._objective.insertSymbol(marker, -strength);
+        }
+    };
+    /**
+     * Get the first Slack or Error symbol in the row.
+     *
+     * If no such symbol is present, an invalid symbol will be returned.
+     *
+     * @private
+     */
+    Solver.prototype._anyPivotableSymbol = function (row) {
+        var cells = row.cells();
+        for (var i = 0, n = cells.size(); i < n; ++i) {
+            var pair = cells.itemAt(i);
+            var type = pair.first.type();
+            if (type === SymbolType.Slack || type === SymbolType.Error) {
+                return pair.first;
+            }
+        }
+        return INVALID_SYMBOL;
+    };
+    /**
+     * Returns a new Symbol of the given type.
+     *
+     * @private
+     */
+    Solver.prototype._makeSymbol = function (type) {
+        return new Symbol(type, this._idTick++);
+    };
+    return Solver;
+}());
+export { Solver };
+/**
+ * Test whether a value is approximately zero.
+ * @private
+ */
+function nearZero(value) {
+    var eps = 1.0e-8;
+    return value < 0.0 ? -value < eps : value < eps;
+}
+/**
+ * An internal function for creating a constraint map.
+ * @private
+ */
+function createCnMap() {
+    return createMap(Constraint.Compare);
+}
+/**
+ * An internal function for creating a row map.
+ * @private
+ */
+function createRowMap() {
+    return createMap(Symbol.Compare);
+}
+/**
+ * An internal function for creating a variable map.
+ * @private
+ */
+function createVarMap() {
+    return createMap(Variable.Compare);
+}
+/**
+ * An internal function for creating an edit map.
+ * @private
+ */
+function createEditMap() {
+    return createMap(Variable.Compare);
+}
+/**
+ * An enum defining the available symbol types.
+ * @private
+ */
+var SymbolType;
+(function (SymbolType) {
+    SymbolType[SymbolType["Invalid"] = 0] = "Invalid";
+    SymbolType[SymbolType["External"] = 1] = "External";
+    SymbolType[SymbolType["Slack"] = 2] = "Slack";
+    SymbolType[SymbolType["Error"] = 3] = "Error";
+    SymbolType[SymbolType["Dummy"] = 4] = "Dummy";
+})(SymbolType || (SymbolType = {}));
+/**
+ * An internal class representing a symbol in the solver.
+ * @private
+ */
+var Symbol = /** @class */ (function () {
+    /**
+     * Construct a new Symbol
+     *
+     * @param [type] The type of the symbol.
+     * @param [id] The unique id number of the symbol.
+     */
+    function Symbol(type, id) {
+        this._id = id;
+        this._type = type;
+    }
+    /**
+     * The static Symbol comparison function.
+     */
+    Symbol.Compare = function (a, b) {
+        return a.id() - b.id();
+    };
+    /**
+     * Returns the unique id number of the symbol.
+     */
+    Symbol.prototype.id = function () {
+        return this._id;
+    };
+    /**
+     * Returns the type of the symbol.
+     */
+    Symbol.prototype.type = function () {
+        return this._type;
+    };
+    return Symbol;
+}());
+/**
+ * A static invalid symbol
+ * @private
+ */
+var INVALID_SYMBOL = new Symbol(SymbolType.Invalid, -1);
+/**
+ * An internal row class used by the solver.
+ * @private
+ */
+var Row = /** @class */ (function () {
+    /**
+     * Construct a new Row.
+     */
+    function Row(constant) {
+        if (constant === void 0) { constant = 0.0; }
+        this._cellMap = createMap(Symbol.Compare);
+        this._constant = constant;
+    }
+    /**
+     * Returns the mapping of symbols to coefficients.
+     */
+    Row.prototype.cells = function () {
+        return this._cellMap;
+    };
+    /**
+     * Returns the constant for the row.
+     */
+    Row.prototype.constant = function () {
+        return this._constant;
+    };
+    /**
+     * Returns true if the row is a constant value.
+     */
+    Row.prototype.isConstant = function () {
+        return this._cellMap.empty();
+    };
+    /**
+     * Returns true if the Row has all dummy symbols.
+     */
+    Row.prototype.allDummies = function () {
+        var cells = this._cellMap;
+        for (var i = 0, n = cells.size(); i < n; ++i) {
+            var pair = cells.itemAt(i);
+            if (pair.first.type() !== SymbolType.Dummy) {
+                return false;
+            }
+        }
+        return true;
+    };
+    /**
+     * Create a copy of the row.
+     */
+    Row.prototype.copy = function () {
+        var theCopy = new Row(this._constant);
+        theCopy._cellMap = this._cellMap.copy();
+        return theCopy;
+    };
+    /**
+     * Add a constant value to the row constant.
+     *
+     * Returns the new value of the constant.
+     */
+    Row.prototype.add = function (value) {
+        return this._constant += value;
+    };
+    /**
+     * Insert the symbol into the row with the given coefficient.
+     *
+     * If the symbol already exists in the row, the coefficient
+     * will be added to the existing coefficient. If the resulting
+     * coefficient is zero, the symbol will be removed from the row.
+     */
+    Row.prototype.insertSymbol = function (symbol, coefficient) {
+        if (coefficient === void 0) { coefficient = 1.0; }
+        var pair = this._cellMap.setDefault(symbol, function () { return 0.0; });
+        if (nearZero(pair.second += coefficient)) {
+            this._cellMap.erase(symbol);
+        }
+    };
+    /**
+     * Insert a row into this row with a given coefficient.
+     *
+     * The constant and the cells of the other row will be
+     * multiplied by the coefficient and added to this row. Any
+     * cell with a resulting coefficient of zero will be removed
+     * from the row.
+     */
+    Row.prototype.insertRow = function (other, coefficient) {
+        if (coefficient === void 0) { coefficient = 1.0; }
+        this._constant += other._constant * coefficient;
+        var cells = other._cellMap;
+        for (var i = 0, n = cells.size(); i < n; ++i) {
+            var pair = cells.itemAt(i);
+            this.insertSymbol(pair.first, pair.second * coefficient);
+        }
+    };
+    /**
+     * Remove a symbol from the row.
+     */
+    Row.prototype.removeSymbol = function (symbol) {
+        this._cellMap.erase(symbol);
+    };
+    /**
+     * Reverse the sign of the constant and cells in the row.
+     */
+    Row.prototype.reverseSign = function () {
+        this._constant = -this._constant;
+        var cells = this._cellMap;
+        for (var i = 0, n = cells.size(); i < n; ++i) {
+            var pair = cells.itemAt(i);
+            pair.second = -pair.second;
+        }
+    };
+    /**
+     * Solve the row for the given symbol.
+     *
+     * This method assumes the row is of the form
+     * a * x + b * y + c = 0 and (assuming solve for x) will modify
+     * the row to represent the right hand side of
+     * x = -b/a * y - c / a. The target symbol will be removed from
+     * the row, and the constant and other cells will be multiplied
+     * by the negative inverse of the target coefficient.
+     *
+     * The given symbol *must* exist in the row.
+     */
+    Row.prototype.solveFor = function (symbol) {
+        var cells = this._cellMap;
+        var pair = cells.erase(symbol);
+        var coeff = -1.0 / pair.second;
+        this._constant *= coeff;
+        for (var i = 0, n = cells.size(); i < n; ++i) {
+            cells.itemAt(i).second *= coeff;
+        }
+    };
+    /**
+     * Solve the row for the given symbols.
+     *
+     * This method assumes the row is of the form
+     * x = b * y + c and will solve the row such that
+     * y = x / b - c / b. The rhs symbol will be removed from the
+     * row, the lhs added, and the result divided by the negative
+     * inverse of the rhs coefficient.
+     *
+     * The lhs symbol *must not* exist in the row, and the rhs
+     * symbol must* exist in the row.
+     */
+    Row.prototype.solveForEx = function (lhs, rhs) {
+        this.insertSymbol(lhs, -1.0);
+        this.solveFor(rhs);
+    };
+    /**
+     * Returns the coefficient for the given symbol.
+     */
+    Row.prototype.coefficientFor = function (symbol) {
+        var pair = this._cellMap.find(symbol);
+        return pair !== undefined ? pair.second : 0.0;
+    };
+    /**
+     * Substitute a symbol with the data from another row.
+     *
+     * Given a row of the form a * x + b and a substitution of the
+     * form x = 3 * y + c the row will be updated to reflect the
+     * expression 3 * a * y + a * c + b.
+     *
+     * If the symbol does not exist in the row, this is a no-op.
+     */
+    Row.prototype.substitute = function (symbol, row) {
+        var pair = this._cellMap.erase(symbol);
+        if (pair !== undefined) {
+            this.insertRow(row, pair.second);
+        }
+    };
+    return Row;
+}());

--- a/es/strength.d.ts
+++ b/es/strength.d.ts
@@ -1,0 +1,36 @@
+/**
+ * @class Strength
+ */
+export declare class Strength {
+    /**
+     * Create a new symbolic strength.
+     *
+     * @param {Number} a strong
+     * @param {Number} b medium
+     * @param {Number} c weak
+     * @param {Number} [w] weight
+     * @return {Number} strength
+    */
+    static create(a: number, b: number, c: number, w?: number): number;
+    /**
+     * The 'required' symbolic strength.
+     */
+    static required: number;
+    /**
+     * The 'strong' symbolic strength.
+     */
+    static strong: number;
+    /**
+     * The 'medium' symbolic strength.
+     */
+    static medium: number;
+    /**
+     * The 'weak' symbolic strength.
+     */
+    static weak: number;
+    /**
+     * Clip a symbolic strength to the allowed min and max.
+     * @private
+     */
+    static clip(value: number): number;
+}

--- a/es/strength.js
+++ b/es/strength.js
@@ -1,0 +1,56 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014, Nucleic Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|
+| The full license is in the file COPYING.txt, distributed with this software.
+|----------------------------------------------------------------------------*/
+/**
+ * @class Strength
+ */
+var Strength = /** @class */ (function () {
+    function Strength() {
+    }
+    /**
+     * Create a new symbolic strength.
+     *
+     * @param {Number} a strong
+     * @param {Number} b medium
+     * @param {Number} c weak
+     * @param {Number} [w] weight
+     * @return {Number} strength
+    */
+    Strength.create = function (a, b, c, w) {
+        if (w === void 0) { w = 1.0; }
+        var result = 0.0;
+        result += Math.max(0.0, Math.min(1000.0, a * w)) * 1000000.0;
+        result += Math.max(0.0, Math.min(1000.0, b * w)) * 1000.0;
+        result += Math.max(0.0, Math.min(1000.0, c * w));
+        return result;
+    };
+    /**
+     * Clip a symbolic strength to the allowed min and max.
+     * @private
+     */
+    Strength.clip = function (value) {
+        return Math.max(0.0, Math.min(Strength.required, value));
+    };
+    /**
+     * The 'required' symbolic strength.
+     */
+    Strength.required = Strength.create(1000.0, 1000.0, 1000.0);
+    /**
+     * The 'strong' symbolic strength.
+     */
+    Strength.strong = Strength.create(1.0, 0.0, 0.0);
+    /**
+     * The 'medium' symbolic strength.
+     */
+    Strength.medium = Strength.create(0.0, 1.0, 0.0);
+    /**
+     * The 'weak' symbolic strength.
+     */
+    Strength.weak = Strength.create(0.0, 0.0, 1.0);
+    return Strength;
+}());
+export { Strength };

--- a/es/variable.d.ts
+++ b/es/variable.d.ts
@@ -1,0 +1,93 @@
+import { Expression } from "./expression";
+/**
+ * The primary user constraint variable.
+ *
+ * @class
+ * @param {String} [name=""] The name to associated with the variable.
+ */
+export declare class Variable {
+    constructor(name?: string);
+    /**
+     * A static variable comparison function.
+     * @private
+     */
+    static Compare(a: Variable, b: Variable): number;
+    /**
+     * Returns the unique id number of the variable.
+     * @private
+     */
+    id(): number;
+    /**
+     * Returns the name of the variable.
+     *
+     * @return {String} name of the variable
+     */
+    name(): string;
+    /**
+     * Set the name of the variable.
+     *
+     * @param {String} name Name of the variable
+     */
+    setName(name: string): void;
+    /**
+     * Returns the user context object of the variable.
+     * @private
+     */
+    context(): any;
+    /**
+     * Set the user context object of the variable.
+     * @private
+     */
+    setContext(context: any): void;
+    /**
+     * Returns the value of the variable.
+     *
+     * @return {Number} Calculated value
+     */
+    value(): number;
+    /**
+     * Set the value of the variable.
+     * @private
+     */
+    setValue(value: number): void;
+    /**
+     * Creates a new Expression by adding a number, variable or expression
+     * to the variable.
+     *
+     * @param {Number|Variable|Expression} value Value to add.
+     * @return {Expression} expression
+     */
+    plus(value: number | Variable | Expression): Expression;
+    /**
+     * Creates a new Expression by substracting a number, variable or expression
+     * from the variable.
+     *
+     * @param {Number|Variable|Expression} value Value to substract.
+     * @return {Expression} expression
+     */
+    minus(value: number | Variable | Expression): Expression;
+    /**
+     * Creates a new Expression by multiplying with a fixed number.
+     *
+     * @param {Number} coefficient Coefficient to multiply with.
+     * @return {Expression} expression
+     */
+    multiply(coefficient: number): Expression;
+    /**
+     * Creates a new Expression by dividing with a fixed number.
+     *
+     * @param {Number} coefficient Coefficient to divide by.
+     * @return {Expression} expression
+     */
+    divide(coefficient: number): Expression;
+    /**
+     * Returns the JSON representation of the variable.
+     * @private
+     */
+    toJSON(): any;
+    toString(): string;
+    private _name;
+    private _value;
+    private _context;
+    private _id;
+}

--- a/es/variable.js
+++ b/es/variable.js
@@ -1,0 +1,140 @@
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014, Nucleic Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|
+| The full license is in the file COPYING.txt, distributed with this software.
+|----------------------------------------------------------------------------*/
+import { Expression } from "./expression";
+/**
+ * The primary user constraint variable.
+ *
+ * @class
+ * @param {String} [name=""] The name to associated with the variable.
+ */
+var Variable = /** @class */ (function () {
+    function Variable(name) {
+        if (name === void 0) { name = ""; }
+        this._value = 0.0;
+        this._context = null;
+        this._id = VarId++;
+        this._name = name;
+    }
+    /**
+     * A static variable comparison function.
+     * @private
+     */
+    Variable.Compare = function (a, b) {
+        return a.id() - b.id();
+    };
+    /**
+     * Returns the unique id number of the variable.
+     * @private
+     */
+    Variable.prototype.id = function () {
+        return this._id;
+    };
+    /**
+     * Returns the name of the variable.
+     *
+     * @return {String} name of the variable
+     */
+    Variable.prototype.name = function () {
+        return this._name;
+    };
+    /**
+     * Set the name of the variable.
+     *
+     * @param {String} name Name of the variable
+     */
+    Variable.prototype.setName = function (name) {
+        this._name = name;
+    };
+    /**
+     * Returns the user context object of the variable.
+     * @private
+     */
+    Variable.prototype.context = function () {
+        return this._context;
+    };
+    /**
+     * Set the user context object of the variable.
+     * @private
+     */
+    Variable.prototype.setContext = function (context) {
+        this._context = context;
+    };
+    /**
+     * Returns the value of the variable.
+     *
+     * @return {Number} Calculated value
+     */
+    Variable.prototype.value = function () {
+        return this._value;
+    };
+    /**
+     * Set the value of the variable.
+     * @private
+     */
+    Variable.prototype.setValue = function (value) {
+        this._value = value;
+    };
+    /**
+     * Creates a new Expression by adding a number, variable or expression
+     * to the variable.
+     *
+     * @param {Number|Variable|Expression} value Value to add.
+     * @return {Expression} expression
+     */
+    Variable.prototype.plus = function (value) {
+        return new Expression(this, value);
+    };
+    /**
+     * Creates a new Expression by substracting a number, variable or expression
+     * from the variable.
+     *
+     * @param {Number|Variable|Expression} value Value to substract.
+     * @return {Expression} expression
+     */
+    Variable.prototype.minus = function (value) {
+        return new Expression(this, typeof value === "number" ? -value : [-1, value]);
+    };
+    /**
+     * Creates a new Expression by multiplying with a fixed number.
+     *
+     * @param {Number} coefficient Coefficient to multiply with.
+     * @return {Expression} expression
+     */
+    Variable.prototype.multiply = function (coefficient) {
+        return new Expression([coefficient, this]);
+    };
+    /**
+     * Creates a new Expression by dividing with a fixed number.
+     *
+     * @param {Number} coefficient Coefficient to divide by.
+     * @return {Expression} expression
+     */
+    Variable.prototype.divide = function (coefficient) {
+        return new Expression([1 / coefficient, this]);
+    };
+    /**
+     * Returns the JSON representation of the variable.
+     * @private
+     */
+    Variable.prototype.toJSON = function () {
+        return {
+            name: this._name,
+            value: this._value,
+        };
+    };
+    Variable.prototype.toString = function () {
+        return this._context + "[" + this._name + ":" + this._value + "]";
+    };
+    return Variable;
+}());
+export { Variable };
+/**
+ * The internal variable id counter.
+ * @private
+ */
+var VarId = 0;

--- a/lib/kiwi.js
+++ b/lib/kiwi.js
@@ -1,30 +1,16 @@
-(function (root, factory) {
-  if (root === undefined && window !== undefined) root = window;
-  if (typeof define === 'function' && define.amd) {
-    // AMD. Register as an anonymous module unless amdModuleId is set
-    define([], function () {
-      return (root['kiwi'] = factory());
-    });
-  } else if (typeof module === 'object' && module.exports) {
-    // Node. Does not work with strict CommonJS, but
-    // only CommonJS-like environments that support module.exports,
-    // like Node.
-    module.exports = factory();
-  } else {
-    root['kiwi'] = factory();
-  }
-}(this, function () {
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+    typeof define === 'function' && define.amd ? define(['exports'], factory) :
+    (factory((global.kiwi = {})));
+}(this, (function (exports) { 'use strict';
 
-/*-----------------------------------------------------------------------------
-| Copyright (c) 2014, Nucleic Development Team.
-|
-| Distributed under the terms of the Modified BSD License.
-|
-| The full license is in the file COPYING.txt, distributed with this software.
-|----------------------------------------------------------------------------*/
-var tsu;
-(function (tsu) {
-
+    /*-----------------------------------------------------------------------------
+    | Copyright (c) 2014, Nucleic Development Team.
+    |
+    | Distributed under the terms of the Modified BSD License.
+    |
+    | The full license is in the file COPYING.txt, distributed with this software.
+    |----------------------------------------------------------------------------*/
     /**
     * An iterator for an array of items.
     */
@@ -55,7 +41,6 @@ var tsu;
         };
         return ArrayIterator;
     })();
-    tsu.ArrayIterator = ArrayIterator;
 
     /**
     * A reverse iterator for an array of items.
@@ -87,9 +72,8 @@ var tsu;
         };
         return ReverseArrayIterator;
     })();
-    tsu.ReverseArrayIterator = ReverseArrayIterator;
 
-    
+
 
     function iter(object) {
         if (object instanceof Array) {
@@ -97,9 +81,8 @@ var tsu;
         }
         return object.__iter__();
     }
-    tsu.iter = iter;
 
-    
+
 
     function reversed(object) {
         if (object instanceof Array) {
@@ -107,15 +90,6 @@ var tsu;
         }
         return object.__reversed__();
     }
-    tsu.reversed = reversed;
-
-    /**
-    * Returns the next value from an iterator, or undefined.
-    */
-    function next(iterator) {
-        return iterator.__next__();
-    }
-    tsu.next = next;
 
 
     function forEach(object, callback) {
@@ -135,19 +109,14 @@ var tsu;
             }
         }
     }
-    tsu.forEach = forEach;
 
-})(tsu || (tsu = {}));
-/*-----------------------------------------------------------------------------
-| Copyright (c) 2014, Nucleic Development Team.
-|
-| Distributed under the terms of the Modified BSD License.
-|
-| The full license is in the file COPYING.txt, distributed with this software.
-|----------------------------------------------------------------------------*/
-var tsu;
-(function (tsu) {
-    
+    /*-----------------------------------------------------------------------------
+    | Copyright (c) 2014, Nucleic Development Team.
+    |
+    | Distributed under the terms of the Modified BSD License.
+    |
+    | The full license is in the file COPYING.txt, distributed with this software.
+    |----------------------------------------------------------------------------*/
 
     /**
     * A class which defines a generic pair object.
@@ -171,19 +140,15 @@ var tsu;
         };
         return Pair;
     })();
-    tsu.Pair = Pair;
-})(tsu || (tsu = {}));
-/*-----------------------------------------------------------------------------
-| Copyright (c) 2014, Nucleic Development Team.
-|
-| Distributed under the terms of the Modified BSD License.
-|
-| The full license is in the file COPYING.txt, distributed with this software.
-|----------------------------------------------------------------------------*/
-/// <reference path="iterator.ts"/>
-/// <reference path="utility.ts"/>
-var tsu;
-(function (tsu) {
+
+    /*-----------------------------------------------------------------------------
+    | Copyright (c) 2014, Nucleic Development Team.
+    |
+    | Distributed under the terms of the Modified BSD License.
+    |
+    | The full license is in the file COPYING.txt, distributed with this software.
+    |----------------------------------------------------------------------------*/
+
     /**
     * Perform a lower bound search on a sorted array.
     *
@@ -210,7 +175,6 @@ var tsu;
         }
         return begin;
     }
-    tsu.lowerBound = lowerBound;
 
     /**
     * Perform a binary search on a sorted array.
@@ -231,7 +195,6 @@ var tsu;
         }
         return index;
     }
-    tsu.binarySearch = binarySearch;
 
     /**
     * Perform a binary find on a sorted array.
@@ -252,19 +215,15 @@ var tsu;
         }
         return item;
     }
-    tsu.binaryFind = binaryFind;
 
-})(tsu || (tsu = {}));
-/*-----------------------------------------------------------------------------
-| Copyright (c) 2014, Nucleic Development Team.
-|
-| Distributed under the terms of the Modified BSD License.
-|
-| The full license is in the file COPYING.txt, distributed with this software.
-|----------------------------------------------------------------------------*/
-/// <reference path="iterator.ts"/>
-var tsu;
-(function (tsu) {
+    /*-----------------------------------------------------------------------------
+    | Copyright (c) 2014, Nucleic Development Team.
+    |
+    | Distributed under the terms of the Modified BSD License.
+    |
+    | The full license is in the file COPYING.txt, distributed with this software.
+    |----------------------------------------------------------------------------*/
+
     /**
     * A base class for implementing array-based data structures.
     *
@@ -333,38 +292,32 @@ var tsu;
         * Returns an iterator over the array of items.
         */
         ArrayBase.prototype.__iter__ = function () {
-            return tsu.iter(this._array);
+            return iter(this._array);
         };
 
         /**
         * Returns a reverse iterator over the array of items.
         */
         ArrayBase.prototype.__reversed__ = function () {
-            return tsu.reversed(this._array);
+            return reversed(this._array);
         };
         return ArrayBase;
     })();
-    tsu.ArrayBase = ArrayBase;
-})(tsu || (tsu = {}));
-/*-----------------------------------------------------------------------------
-| Copyright (c) 2014, Nucleic Development Team.
-|
-| Distributed under the terms of the Modified BSD License.
-|
-| The full license is in the file COPYING.txt, distributed with this software.
-|----------------------------------------------------------------------------*/
-var __extends = this.__extends || function (d, b) {
+
+    /*-----------------------------------------------------------------------------
+    | Copyright (c) 2014, Nucleic Development Team.
+    |
+    | Distributed under the terms of the Modified BSD License.
+    |
+    | The full license is in the file COPYING.txt, distributed with this software.
+    |----------------------------------------------------------------------------*/
+    var __extends = (undefined && undefined.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
     __.prototype = b.prototype;
     d.prototype = new __();
-};
-/// <reference path="algorithm.ts"/>
-/// <reference path="array_base.ts"/>
-/// <reference path="iterator.ts"/>
-/// <reference path="utility.ts"/>
-var tsu;
-(function (tsu) {
+    };
+
     /**
     * A mapping container build on a sorted array.
     *
@@ -395,7 +348,7 @@ var tsu;
         * @param key The key to locate in the array.
         */
         AssociativeArray.prototype.indexOf = function (key) {
-            return tsu.binarySearch(this._array, key, this._wrapped);
+            return binarySearch(this._array, key, this._wrapped);
         };
 
         /**
@@ -404,7 +357,7 @@ var tsu;
         * @param key The key to locate in the array.
         */
         AssociativeArray.prototype.contains = function (key) {
-            return tsu.binarySearch(this._array, key, this._wrapped) >= 0;
+            return binarySearch(this._array, key, this._wrapped) >= 0;
         };
 
         /**
@@ -413,7 +366,7 @@ var tsu;
         * @param key The key to locate in the array.
         */
         AssociativeArray.prototype.find = function (key) {
-            return tsu.binaryFind(this._array, key, this._wrapped);
+            return binaryFind(this._array, key, this._wrapped);
         };
 
         /**
@@ -427,15 +380,15 @@ var tsu;
         */
         AssociativeArray.prototype.setDefault = function (key, factory) {
             var array = this._array;
-            var index = tsu.lowerBound(array, key, this._wrapped);
+            var index = lowerBound(array, key, this._wrapped);
             if (index === array.length) {
-                var pair = new tsu.Pair(key, factory());
+                var pair = new Pair(key, factory());
                 array.push(pair);
                 return pair;
             }
             var currPair = array[index];
             if (this._compare(currPair.first, key) !== 0) {
-                var pair = new tsu.Pair(key, factory());
+                var pair = new Pair(key, factory());
                 array.splice(index, 0, pair);
                 return pair;
             }
@@ -452,15 +405,15 @@ var tsu;
         */
         AssociativeArray.prototype.insert = function (key, value) {
             var array = this._array;
-            var index = tsu.lowerBound(array, key, this._wrapped);
+            var index = lowerBound(array, key, this._wrapped);
             if (index === array.length) {
-                var pair = new tsu.Pair(key, value);
+                var pair = new Pair(key, value);
                 array.push(pair);
                 return pair;
             }
             var currPair = array[index];
             if (this._compare(currPair.first, key) !== 0) {
-                var pair = new tsu.Pair(key, value);
+                var pair = new Pair(key, value);
                 array.splice(index, 0, pair);
                 return pair;
             }
@@ -474,7 +427,7 @@ var tsu;
                 var obj = object;
                 this._array = merge(this._array, obj._array, this._compare);
             } else {
-                tsu.forEach(object, function (pair) {
+                forEach(object, function (pair) {
                     _this.insert(pair.first, pair.second);
                 });
             }
@@ -487,7 +440,7 @@ var tsu;
         */
         AssociativeArray.prototype.erase = function (key) {
             var array = this._array;
-            var index = tsu.binarySearch(array, key, this._wrapped);
+            var index = binarySearch(array, key, this._wrapped);
             if (index < 0) {
                 return undefined;
             }
@@ -507,8 +460,7 @@ var tsu;
             return theCopy;
         };
         return AssociativeArray;
-    })(tsu.ArrayBase);
-    tsu.AssociativeArray = AssociativeArray;
+    })(ArrayBase);
 
     /**
     * An internal which wraps a comparison key function.
@@ -553,185 +505,32 @@ var tsu;
         }
         return merged;
     }
-})(tsu || (tsu = {}));
-/*-----------------------------------------------------------------------------
-| Copyright (c) 2014, Nucleic Development Team.
-|
-| Distributed under the terms of the Modified BSD License.
-|
-| The full license is in the file COPYING.txt, distributed with this software.
-|----------------------------------------------------------------------------*/
-/// <reference path="algorithm.ts"/>
-/// <reference path="array_base.ts"/>
-/// <reference path="associative_array.ts"/>
-/// <reference path="iterator.ts"/>
-/// <reference path="unique_array.ts"/>
-/// <reference path="utility.ts"/>
+    /*-----------------------------------------------------------------------------
+    | Copyright (c) 2014, Nucleic Development Team.
+    |
+    | Distributed under the terms of the Modified BSD License.
+    |
+    | The full license is in the file COPYING.txt, distributed with this software.
+    |----------------------------------------------------------------------------*/
 
-/*-----------------------------------------------------------------------------
-| Copyright (c) 2014, Nucleic Development Team.
-|
-| Distributed under the terms of the Modified BSD License.
-|
-| The full license is in the file COPYING.txt, distributed with this software.
-|----------------------------------------------------------------------------*/
-// <reference path="expression.ts">
-// <reference path="strength.ts">
-/**
- * Kiwi is an efficient implementation of the Cassowary constraint solving
- * algorithm, based on the seminal Cassowary paper.
- * It is *not* a refactoring or port of the original C++ solver, but
- * has been designed from the ground up to be lightweight and fast.
- *
- * **Example**
- *
- * ```javascript
- * var kiwi = require('kiwi');
- *
- * // Create a solver
- * var solver = new kiwi.Solver();
- *
- * // Create and add some editable variables
- * var left = new kiwi.Variable();
- * var width = new kiwi.Variable();
- * solver.addEditVariable(left, kiwi.Strength.strong);
- * solver.addEditVariable(width, kiwi.Strength.strong);
- *
- * // Create a variable calculated through a constraint
- * var centerX = new kiwi.Variable();
- * var expr = new kiwi.Expression([-1, centerX], left, [0.5, width]);
- * solver.addConstraint(new kiwi.Constraint(expr, kiwi.Operator.Eq, kiwi.Strength.required));
- *
- * // Suggest some values to the solver
- * solver.suggestValue(left, 0);
- * solver.suggestValue(width, 500);
- *
- * // Lets solve the problem!
- * solver.updateVariables();
- * assert(centerX.value(), 250);
- * ```
- *
- * ##API Documentation
- * @module kiwi
- */
-var kiwi;
-(function (kiwi) {
-    /**
-     * An enum defining the linear constraint operators.
-     *
-     * |Value|Operator|Description|
-     * |----|-----|-----|
-     * |`Le`|<=|Less than equal|
-     * |`Ge`|>=|Greater than equal|
-     * |`Eq`|==|Equal|
-     *
-     * @enum {Number}
-     */
-    var Operator;
-    (function (Operator) {
-        Operator[Operator["Le"] = 0] = "Le";
-        Operator[Operator["Ge"] = 1] = "Ge";
-        Operator[Operator["Eq"] = 2] = "Eq";
-    })(Operator = kiwi.Operator || (kiwi.Operator = {}));
-    /**
-     * A linear constraint equation.
-     *
-     * A constraint equation is composed of an expression, an operator,
-     * and a strength. The RHS of the equation is implicitly zero.
-     *
-     * @class
-     * @param {Expression} expression The constraint expression (LHS).
-     * @param {Operator} operator The equation operator.
-     * @param {Expression} [rhs] Right hand side of the expression.
-     * @param {Number} [strength=Strength.required] The strength of the constraint.
-     */
-    var Constraint = /** @class */ (function () {
-        function Constraint(expression, operator, rhs, strength) {
-            if (strength === void 0) { strength = kiwi.Strength.required; }
-            this._id = CnId++;
-            this._operator = operator;
-            this._strength = kiwi.Strength.clip(strength);
-            if ((rhs === undefined) && (expression instanceof kiwi.Expression)) {
-                this._expression = expression;
-            }
-            else {
-                this._expression = expression.minus(rhs);
-            }
-        }
-        /**
-          * A static constraint comparison function.
-          * @private
-          */
-        Constraint.Compare = function (a, b) {
-            return a.id() - b.id();
-        };
-        /**
-         * Returns the unique id number of the constraint.
-         * @private
-         */
-        Constraint.prototype.id = function () {
-            return this._id;
-        };
-        /**
-         * Returns the expression of the constraint.
-         *
-         * @return {Expression} expression
-         */
-        Constraint.prototype.expression = function () {
-            return this._expression;
-        };
-        /**
-         * Returns the relational operator of the constraint.
-         *
-         * @return {Operator} linear constraint operator
-         */
-        Constraint.prototype.op = function () {
-            return this._operator;
-        };
-        /**
-         * Returns the strength of the constraint.
-         *
-         * @return {Number} strength
-         */
-        Constraint.prototype.strength = function () {
-            return this._strength;
-        };
-        Constraint.prototype.toString = function () {
-            return this._expression.toString() + " " + ["<=", ">=", "="][this._operator] + " 0 (" + this._strength.toString() + ")";
-        };
-        return Constraint;
-    }());
-    kiwi.Constraint = Constraint;
-    /**
-     * The internal constraint id counter.
-     * @private
-     */
-    var CnId = 0;
-})(kiwi || (kiwi = {}));
-/*-----------------------------------------------------------------------------
-| Copyright (c) 2014, Nucleic Development Team.
-|
-| Distributed under the terms of the Modified BSD License.
-|
-| The full license is in the file COPYING.txt, distributed with this software.
-|----------------------------------------------------------------------------*/
-/// <reference path="../thirdparty/tsu.d.ts"/>
-var kiwi;
-(function (kiwi) {
+    /*-----------------------------------------------------------------------------
+    | Copyright (c) 2014, Nucleic Development Team.
+    |
+    | Distributed under the terms of the Modified BSD License.
+    |
+    | The full license is in the file COPYING.txt, distributed with this software.
+    |----------------------------------------------------------------------------*/
     function createMap(compare) {
-        return new tsu.AssociativeArray(compare);
+        return new AssociativeArray(compare);
     }
-    kiwi.createMap = createMap;
-})(kiwi || (kiwi = {}));
-/*-----------------------------------------------------------------------------
-| Copyright (c) 2014, Nucleic Development Team.
-|
-| Distributed under the terms of the Modified BSD License.
-|
-| The full license is in the file COPYING.txt, distributed with this software.
-|----------------------------------------------------------------------------*/
-var kiwi;
-(function (kiwi) {
+
+    /*-----------------------------------------------------------------------------
+    | Copyright (c) 2014, Nucleic Development Team.
+    |
+    | Distributed under the terms of the Modified BSD License.
+    |
+    | The full license is in the file COPYING.txt, distributed with this software.
+    |----------------------------------------------------------------------------*/
     /**
      * The primary user constraint variable.
      *
@@ -813,7 +612,7 @@ var kiwi;
          * @return {Expression} expression
          */
         Variable.prototype.plus = function (value) {
-            return new kiwi.Expression(this, value);
+            return new Expression(this, value);
         };
         /**
          * Creates a new Expression by substracting a number, variable or expression
@@ -823,7 +622,7 @@ var kiwi;
          * @return {Expression} expression
          */
         Variable.prototype.minus = function (value) {
-            return new kiwi.Expression(this, typeof value === "number" ? -value : [-1, value]);
+            return new Expression(this, typeof value === "number" ? -value : [-1, value]);
         };
         /**
          * Creates a new Expression by multiplying with a fixed number.
@@ -832,7 +631,7 @@ var kiwi;
          * @return {Expression} expression
          */
         Variable.prototype.multiply = function (coefficient) {
-            return new kiwi.Expression([coefficient, this]);
+            return new Expression([coefficient, this]);
         };
         /**
          * Creates a new Expression by dividing with a fixed number.
@@ -841,7 +640,7 @@ var kiwi;
          * @return {Expression} expression
          */
         Variable.prototype.divide = function (coefficient) {
-            return new kiwi.Expression([1 / coefficient, this]);
+            return new Expression([1 / coefficient, this]);
         };
         /**
          * Returns the JSON representation of the variable.
@@ -850,7 +649,7 @@ var kiwi;
         Variable.prototype.toJSON = function () {
             return {
                 name: this._name,
-                value: this._value
+                value: this._value,
             };
         };
         Variable.prototype.toString = function () {
@@ -858,25 +657,19 @@ var kiwi;
         };
         return Variable;
     }());
-    kiwi.Variable = Variable;
     /**
      * The internal variable id counter.
      * @private
      */
     var VarId = 0;
-})(kiwi || (kiwi = {}));
-/*-----------------------------------------------------------------------------
-| Copyright (c) 2014, Nucleic Development Team.
-|
-| Distributed under the terms of the Modified BSD License.
-|
-| The full license is in the file COPYING.txt, distributed with this software.
-|----------------------------------------------------------------------------*/
-/// <reference path="../thirdparty/tsu.d.ts"/>
-/// <reference path="maptype.ts"/>
-/// <reference path="variable.ts"/>
-var kiwi;
-(function (kiwi) {
+
+    /*-----------------------------------------------------------------------------
+    | Copyright (c) 2014, Nucleic Development Team.
+    |
+    | Distributed under the terms of the Modified BSD License.
+    |
+    | The full license is in the file COPYING.txt, distributed with this software.
+    |----------------------------------------------------------------------------*/
     /**
      * An expression of variable terms and a constant.
      *
@@ -981,7 +774,6 @@ var kiwi;
         };
         return Expression;
     }());
-    kiwi.Expression = Expression;
     /**
      * An internal argument parsing function.
      * @private
@@ -989,13 +781,13 @@ var kiwi;
     function parseArgs(args) {
         var constant = 0.0;
         var factory = function () { return 0.0; };
-        var terms = kiwi.createMap(kiwi.Variable.Compare);
+        var terms = createMap(Variable.Compare);
         for (var i = 0, n = args.length; i < n; ++i) {
             var item = args[i];
             if (typeof item === "number") {
                 constant += item;
             }
-            else if (item instanceof kiwi.Variable) {
+            else if (item instanceof Variable) {
                 terms.setDefault(item, factory).second += 1.0;
             }
             else if (item instanceof Expression) {
@@ -1015,7 +807,7 @@ var kiwi;
                 if (typeof value !== "number") {
                     throw new Error("array item 0 must be a number");
                 }
-                if (value2 instanceof kiwi.Variable) {
+                if (value2 instanceof Variable) {
                     terms.setDefault(value2, factory).second += value;
                 }
                 else if (value2 instanceof Expression) {
@@ -1036,21 +828,20 @@ var kiwi;
         }
         return { terms: terms, constant: constant };
     }
-})(kiwi || (kiwi = {}));
-/*-----------------------------------------------------------------------------
-| Copyright (c) 2014, Nucleic Development Team.
-|
-| Distributed under the terms of the Modified BSD License.
-|
-| The full license is in the file COPYING.txt, distributed with this software.
-|----------------------------------------------------------------------------*/
-var kiwi;
-(function (kiwi) {
+
+    /*-----------------------------------------------------------------------------
+    | Copyright (c) 2014, Nucleic Development Team.
+    |
+    | Distributed under the terms of the Modified BSD License.
+    |
+    | The full license is in the file COPYING.txt, distributed with this software.
+    |----------------------------------------------------------------------------*/
     /**
      * @class Strength
      */
-    var Strength;
-    (function (Strength) {
+    var Strength = /** @class */ (function () {
+        function Strength() {
+        }
         /**
          * Create a new symbolic strength.
          *
@@ -1059,57 +850,134 @@ var kiwi;
          * @param {Number} c weak
          * @param {Number} [w] weight
          * @return {Number} strength
-         */
-        function create(a, b, c, w) {
+        */
+        Strength.create = function (a, b, c, w) {
             if (w === void 0) { w = 1.0; }
             var result = 0.0;
             result += Math.max(0.0, Math.min(1000.0, a * w)) * 1000000.0;
             result += Math.max(0.0, Math.min(1000.0, b * w)) * 1000.0;
             result += Math.max(0.0, Math.min(1000.0, c * w));
             return result;
-        }
-        Strength.create = create;
-        /**
-         * The 'required' symbolic strength.
-         */
-        Strength.required = create(1000.0, 1000.0, 1000.0);
-        /**
-         * The 'strong' symbolic strength.
-         */
-        Strength.strong = create(1.0, 0.0, 0.0);
-        /**
-         * The 'medium' symbolic strength.
-         */
-        Strength.medium = create(0.0, 1.0, 0.0);
-        /**
-         * The 'weak' symbolic strength.
-         */
-        Strength.weak = create(0.0, 0.0, 1.0);
+        };
         /**
          * Clip a symbolic strength to the allowed min and max.
          * @private
          */
-        function clip(value) {
+        Strength.clip = function (value) {
             return Math.max(0.0, Math.min(Strength.required, value));
+        };
+        /**
+         * The 'required' symbolic strength.
+         */
+        Strength.required = Strength.create(1000.0, 1000.0, 1000.0);
+        /**
+         * The 'strong' symbolic strength.
+         */
+        Strength.strong = Strength.create(1.0, 0.0, 0.0);
+        /**
+         * The 'medium' symbolic strength.
+         */
+        Strength.medium = Strength.create(0.0, 1.0, 0.0);
+        /**
+         * The 'weak' symbolic strength.
+         */
+        Strength.weak = Strength.create(0.0, 0.0, 1.0);
+        return Strength;
+    }());
+
+    /*-----------------------------------------------------------------------------
+    | Copyright (c) 2014, Nucleic Development Team.
+    |
+    | Distributed under the terms of the Modified BSD License.
+    |
+    | The full license is in the file COPYING.txt, distributed with this software.
+    |----------------------------------------------------------------------------*/
+    (function (Operator) {
+        Operator[Operator["Le"] = 0] = "Le";
+        Operator[Operator["Ge"] = 1] = "Ge";
+        Operator[Operator["Eq"] = 2] = "Eq";
+    })(exports.Operator || (exports.Operator = {}));
+    /**
+     * A linear constraint equation.
+     *
+     * A constraint equation is composed of an expression, an operator,
+     * and a strength. The RHS of the equation is implicitly zero.
+     *
+     * @class
+     * @param {Expression} expression The constraint expression (LHS).
+     * @param {Operator} operator The equation operator.
+     * @param {Expression} [rhs] Right hand side of the expression.
+     * @param {Number} [strength=Strength.required] The strength of the constraint.
+     */
+    var Constraint = /** @class */ (function () {
+        function Constraint(expression, operator, rhs, strength) {
+            if (strength === void 0) { strength = Strength.required; }
+            this._id = CnId++;
+            this._operator = operator;
+            this._strength = Strength.clip(strength);
+            if ((rhs === undefined) && (expression instanceof Expression)) {
+                this._expression = expression;
+            }
+            else {
+                this._expression = expression.minus(rhs);
+            }
         }
-        Strength.clip = clip;
-    })(Strength = kiwi.Strength || (kiwi.Strength = {}));
-})(kiwi || (kiwi = {}));
-/*-----------------------------------------------------------------------------
-| Copyright (c) 2014, Nucleic Development Team.
-|
-| Distributed under the terms of the Modified BSD License.
-|
-| The full license is in the file COPYING.txt, distributed with this software.
-|----------------------------------------------------------------------------*/
-/// <reference path="../thirdparty/tsu.d.ts"/>
-/// <reference path="constraint.ts"/>
-/// <reference path="expression.ts"/>
-/// <reference path="maptype.ts"/>
-/// <reference path="strength.ts"/>
-/// <reference path="variable.ts"/>
-var kiwi;
-(function (kiwi) {
+        /**
+         * A static constraint comparison function.
+         * @private
+         */
+        Constraint.Compare = function (a, b) {
+            return a.id() - b.id();
+        };
+        /**
+         * Returns the unique id number of the constraint.
+         * @private
+         */
+        Constraint.prototype.id = function () {
+            return this._id;
+        };
+        /**
+         * Returns the expression of the constraint.
+         *
+         * @return {Expression} expression
+         */
+        Constraint.prototype.expression = function () {
+            return this._expression;
+        };
+        /**
+         * Returns the relational operator of the constraint.
+         *
+         * @return {Operator} linear constraint operator
+         */
+        Constraint.prototype.op = function () {
+            return this._operator;
+        };
+        /**
+         * Returns the strength of the constraint.
+         *
+         * @return {Number} strength
+         */
+        Constraint.prototype.strength = function () {
+            return this._strength;
+        };
+        Constraint.prototype.toString = function () {
+            return this._expression.toString() + " " + ["<=", ">=", "="][this._operator] + " 0 (" + this._strength.toString() + ")";
+        };
+        return Constraint;
+    }());
+    /**
+     * The internal constraint id counter.
+     * @private
+     */
+    var CnId = 0;
+
+    /*-----------------------------------------------------------------------------
+    | Copyright (c) 2014, Nucleic Development Team.
+    |
+    | Distributed under the terms of the Modified BSD License.
+    |
+    | The full license is in the file COPYING.txt, distributed with this software.
+    |----------------------------------------------------------------------------*/
     /**
      * The constraint solver class.
      *
@@ -1138,8 +1006,8 @@ var kiwi;
          * @param {Number} [strength=Strength.required] Strength
          */
         Solver.prototype.createConstraint = function (lhs, operator, rhs, strength) {
-            if (strength === void 0) { strength = kiwi.Strength.required; }
-            var cn = new kiwi.Constraint(lhs, operator, rhs, strength);
+            if (strength === void 0) { strength = Strength.required; }
+            var cn = new Constraint(lhs, operator, rhs, strength);
             this.addConstraint(cn);
             return cn;
         };
@@ -1248,12 +1116,12 @@ var kiwi;
             if (editPair !== undefined) {
                 throw new Error("duplicate edit variable");
             }
-            strength = kiwi.Strength.clip(strength);
-            if (strength === kiwi.Strength.required) {
+            strength = Strength.clip(strength);
+            if (strength === Strength.required) {
                 throw new Error("bad required strength");
             }
-            var expr = new kiwi.Expression(variable);
-            var cn = new kiwi.Constraint(expr, kiwi.Operator.Eq, undefined, strength);
+            var expr = new Expression(variable);
+            var cn = new Constraint(expr, exports.Operator.Eq, undefined, strength);
             this.addConstraint(cn);
             var tag = this._cnMap.find(cn).second;
             var info = { tag: tag, constraint: cn, constant: 0.0 };
@@ -1395,14 +1263,14 @@ var kiwi;
             var strength = constraint.strength();
             var tag = { marker: INVALID_SYMBOL, other: INVALID_SYMBOL };
             switch (constraint.op()) {
-                case kiwi.Operator.Le:
-                case kiwi.Operator.Ge:
+                case exports.Operator.Le:
+                case exports.Operator.Ge:
                     {
-                        var coeff = constraint.op() === kiwi.Operator.Le ? 1.0 : -1.0;
+                        var coeff = constraint.op() === exports.Operator.Le ? 1.0 : -1.0;
                         var slack = this._makeSymbol(SymbolType.Slack);
                         tag.marker = slack;
                         row.insertSymbol(slack, coeff);
-                        if (strength < kiwi.Strength.required) {
+                        if (strength < Strength.required) {
                             var error = this._makeSymbol(SymbolType.Error);
                             tag.other = error;
                             row.insertSymbol(error, -coeff);
@@ -1410,9 +1278,9 @@ var kiwi;
                         }
                         break;
                     }
-                case kiwi.Operator.Eq:
+                case exports.Operator.Eq:
                     {
-                        if (strength < kiwi.Strength.required) {
+                        if (strength < Strength.required) {
                             var errplus = this._makeSymbol(SymbolType.Error);
                             var errminus = this._makeSymbol(SymbolType.Error);
                             tag.marker = errplus;
@@ -1794,7 +1662,6 @@ var kiwi;
         };
         return Solver;
     }());
-    kiwi.Solver = Solver;
     /**
      * Test whether a value is approximately zero.
      * @private
@@ -1808,28 +1675,28 @@ var kiwi;
      * @private
      */
     function createCnMap() {
-        return kiwi.createMap(kiwi.Constraint.Compare);
+        return createMap(Constraint.Compare);
     }
     /**
      * An internal function for creating a row map.
      * @private
      */
     function createRowMap() {
-        return kiwi.createMap(Symbol.Compare);
+        return createMap(Symbol.Compare);
     }
     /**
      * An internal function for creating a variable map.
      * @private
      */
     function createVarMap() {
-        return kiwi.createMap(kiwi.Variable.Compare);
+        return createMap(Variable.Compare);
     }
     /**
      * An internal function for creating an edit map.
      * @private
      */
     function createEditMap() {
-        return kiwi.createMap(kiwi.Variable.Compare);
+        return createMap(Variable.Compare);
     }
     /**
      * An enum defining the available symbol types.
@@ -1893,7 +1760,7 @@ var kiwi;
          */
         function Row(constant) {
             if (constant === void 0) { constant = 0.0; }
-            this._cellMap = kiwi.createMap(Symbol.Compare);
+            this._cellMap = createMap(Symbol.Compare);
             this._constant = constant;
         }
         /**
@@ -2052,21 +1919,22 @@ var kiwi;
         };
         return Row;
     }());
-})(kiwi || (kiwi = {}));
-/*-----------------------------------------------------------------------------
-| Copyright (c) 2014-2018, Nucleic Development Team & H. Rutjes.
-|
-| Distributed under the terms of the Modified BSD License.
-|
-| The full license is in the file COPYING.txt, distributed with this software.
-|----------------------------------------------------------------------------*/
-/// <reference path="constraint.ts"/>
-/// <reference path="expression.ts"/>
-/// <reference path="maptype.ts"/>
-/// <reference path="solver.ts"/>
-/// <reference path="strength.ts"/>
-/// <reference path="variable.ts"/>
 
-return kiwi;
+    /*-----------------------------------------------------------------------------
+    | Copyright (c) 2014-2018, Nucleic Development Team & H. Rutjes.
+    |
+    | Distributed under the terms of the Modified BSD License.
+    |
+    | The full license is in the file COPYING.txt, distributed with this software.
+    |----------------------------------------------------------------------------*/
 
-}));
+    exports.Constraint = Constraint;
+    exports.Expression = Expression;
+    exports.createMap = createMap;
+    exports.Solver = Solver;
+    exports.Strength = Strength;
+    exports.Variable = Variable;
+
+    Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/lib/kiwi.js
+++ b/lib/kiwi.js
@@ -11,117 +11,134 @@
     |
     | The full license is in the file COPYING.txt, distributed with this software.
     |----------------------------------------------------------------------------*/
-    /**
-    * An iterator for an array of items.
-    */
-    var ArrayIterator = (function () {
-        /*
-        * Construct a new ArrayIterator.
-        *
-        * @param array The array of items to iterate.
-        * @param [index] The index at which to start iteration.
-        */
-        function ArrayIterator(array, index) {
-            if (typeof index === "undefined") { index = 0; }
-            this._array = array;
-            this._index = Math.max(0, Math.min(index, array.length));
-        }
-        /**
-        * Returns the next item from the iterator or undefined.
-        */
-        ArrayIterator.prototype.__next__ = function () {
-            return this._array[this._index++];
-        };
-
-        /**
-        * Returns this same iterator.
-        */
-        ArrayIterator.prototype.__iter__ = function () {
-            return this;
-        };
-        return ArrayIterator;
-    })();
-
-    /**
-    * A reverse iterator for an array of items.
-    */
-    var ReverseArrayIterator = (function () {
-        /**
-        * Construct a new ReverseArrayIterator.
-        *
-        * @param array The array of items to iterate.
-        * @param [index] The index at which to start iteration.
-        */
-        function ReverseArrayIterator(array, index) {
-            if (typeof index === "undefined") { index = array.length; }
-            this._array = array;
-            this._index = Math.max(0, Math.min(index, array.length));
-        }
-        /**
-        * Returns the next item from the iterator or undefined.
-        */
-        ReverseArrayIterator.prototype.__next__ = function () {
-            return this._array[--this._index];
-        };
-
-        /**
-        * Returns this same iterator.
-        */
-        ReverseArrayIterator.prototype.__iter__ = function () {
-            return this;
-        };
-        return ReverseArrayIterator;
-    })();
-
-
-
-    function iter(object) {
-        if (object instanceof Array) {
-            return new ArrayIterator(object);
-        }
-        return object.__iter__();
-    }
-
-
-
-    function reversed(object) {
-        if (object instanceof Array) {
-            return new ReverseArrayIterator(object);
-        }
-        return object.__reversed__();
-    }
-
-
-    function forEach(object, callback) {
-        if (object instanceof Array) {
-            for (var i = 0, n = object.length; i < n; ++i) {
-                if (callback(object[i]) === false) {
-                    return;
-                }
+    var __assign = (undefined && undefined.__assign) || function () {
+        __assign = Object.assign || function(t) {
+            for (var s, i = 1, n = arguments.length; i < n; i++) {
+                s = arguments[i];
+                for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                    t[p] = s[p];
             }
-        } else {
-            var value;
-            var it = object.__iter__();
-            while ((value = it.__next__()) !== undefined) {
-                if (callback(value) === false) {
-                    return;
-                }
-            }
-        }
+            return t;
+        };
+        return __assign.apply(this, arguments);
+    };
+    function createMap(compare) {
+        return new IndexedMap();
     }
-
-    /*-----------------------------------------------------------------------------
-    | Copyright (c) 2014, Nucleic Development Team.
-    |
-    | Distributed under the terms of the Modified BSD License.
-    |
-    | The full license is in the file COPYING.txt, distributed with this software.
-    |----------------------------------------------------------------------------*/
-
+    var IndexedMap = /** @class */ (function () {
+        function IndexedMap() {
+            this._index = {};
+            this._array = [];
+        }
+        /**
+         * Returns the number of items in the array.
+         */
+        IndexedMap.prototype.size = function () {
+            return this._array.length;
+        };
+        /**
+        * Returns true if the array is empty.
+        */
+        IndexedMap.prototype.empty = function () {
+            return this._array.length === 0;
+        };
+        /**
+         * Returns the item at the given array index.
+         *
+         * @param index The integer index of the desired item.
+         */
+        IndexedMap.prototype.itemAt = function (index) {
+            return this._array[index];
+        };
+        /**
+        * Returns true if the key is in the array, false otherwise.
+        *
+        * @param key The key to locate in the array.
+        */
+        IndexedMap.prototype.contains = function (key) {
+            return this._index[key.id()] !== undefined;
+        };
+        /**
+         * Returns the pair associated with the given key, or undefined.
+         *
+         * @param key The key to locate in the array.
+         */
+        IndexedMap.prototype.find = function (key) {
+            var i = this._index[key.id()];
+            return i === undefined ? undefined : this._array[i];
+        };
+        /**
+         * Returns the pair associated with the key if it exists.
+         *
+         * If the key does not exist, a new pair will be created and
+         * inserted using the value created by the given factory.
+         *
+         * @param key The key to locate in the array.
+         * @param factory The function which creates the default value.
+         */
+        IndexedMap.prototype.setDefault = function (key, factory) {
+            var i = this._index[key.id()];
+            if (i === undefined) {
+                var pair = new Pair(key, factory());
+                this._index[key.id()] = this._array.length;
+                this._array.push(pair);
+                return pair;
+            }
+            else {
+                return this._array[i];
+            }
+        };
+        /**
+         * Insert the pair into the array and return the pair.
+         *
+         * This will overwrite any existing entry in the array.
+         *
+         * @param key The key portion of the pair.
+         * @param value The value portion of the pair.
+         */
+        IndexedMap.prototype.insert = function (key, value) {
+            var pair = new Pair(key, value), i = this._index[key.id()];
+            if (i === undefined) {
+                this._index[key.id()] = this._array.length;
+                this._array.push(pair);
+            }
+            else {
+                this._array[i] = pair;
+            }
+            return pair;
+        };
+        /**
+         * Removes and returns the pair for the given key, or undefined.
+         *
+         * @param key The key to remove from the map.
+         */
+        IndexedMap.prototype.erase = function (key) {
+            var i = this._index[key.id()];
+            if (i === undefined)
+                return undefined;
+            this._index[key.id()] = undefined;
+            var pair = this._array[i], last = this._array.pop();
+            if (pair !== last) {
+                this._array[i] = last;
+                this._index[last.first.id()] = i;
+            }
+            return pair;
+        };
+        /**
+         * Create a copy of this associative array.
+         */
+        IndexedMap.prototype.copy = function () {
+            var copy = new IndexedMap();
+            copy._index = __assign({}, this._index);
+            copy._array = this._array.map(function (p) { return p.copy(); });
+            return copy;
+        };
+        return IndexedMap;
+    }());
     /**
     * A class which defines a generic pair object.
     */
-    var Pair = (function () {
+    var Pair = /** @class */ (function () {
         /**
         * Construct a new Pair object.
         *
@@ -135,394 +152,9 @@
         /**
         * Create a copy of the pair.
         */
-        Pair.prototype.copy = function () {
-            return new Pair(this.first, this.second);
-        };
+        Pair.prototype.copy = function () { return new Pair(this.first, this.second); };
         return Pair;
-    })();
-
-    /*-----------------------------------------------------------------------------
-    | Copyright (c) 2014, Nucleic Development Team.
-    |
-    | Distributed under the terms of the Modified BSD License.
-    |
-    | The full license is in the file COPYING.txt, distributed with this software.
-    |----------------------------------------------------------------------------*/
-
-    /**
-    * Perform a lower bound search on a sorted array.
-    *
-    * @param array The array of sorted items to search.
-    * @param value The value to located in the array.
-    * @param compare The value comparison function.
-    * @returns The index of the first element in the array which
-    *          compares greater than or equal to the given value.
-    */
-    function lowerBound(array, value, compare) {
-        var begin = 0;
-        var n = array.length;
-        var half;
-        var middle;
-        while (n > 0) {
-            half = n >> 1;
-            middle = begin + half;
-            if (compare(array[middle], value) < 0) {
-                begin = middle + 1;
-                n -= half + 1;
-            } else {
-                n = half;
-            }
-        }
-        return begin;
-    }
-
-    /**
-    * Perform a binary search on a sorted array.
-    *
-    * @param array The array of sorted items to search.
-    * @param value The value to located in the array.
-    * @param compare The value comparison function.
-    * @returns The index of the found item, or -1.
-    */
-    function binarySearch(array, value, compare) {
-        var index = lowerBound(array, value, compare);
-        if (index === array.length) {
-            return -1;
-        }
-        var item = array[index];
-        if (compare(item, value) !== 0) {
-            return -1;
-        }
-        return index;
-    }
-
-    /**
-    * Perform a binary find on a sorted array.
-    *
-    * @param array The array of sorted items to search.
-    * @param value The value to located in the array.
-    * @param compare The value comparison function.
-    * @returns The found item in the array, or undefined.
-    */
-    function binaryFind(array, value, compare) {
-        var index = lowerBound(array, value, compare);
-        if (index === array.length) {
-            return undefined;
-        }
-        var item = array[index];
-        if (compare(item, value) !== 0) {
-            return undefined;
-        }
-        return item;
-    }
-
-    /*-----------------------------------------------------------------------------
-    | Copyright (c) 2014, Nucleic Development Team.
-    |
-    | Distributed under the terms of the Modified BSD License.
-    |
-    | The full license is in the file COPYING.txt, distributed with this software.
-    |----------------------------------------------------------------------------*/
-
-    /**
-    * A base class for implementing array-based data structures.
-    *
-    * @class
-    */
-    var ArrayBase = (function () {
-        function ArrayBase() {
-            /*
-            * The internal data array.
-            *
-            * @protected
-            */
-            this._array = [];
-        }
-        /**
-        * Returns the number of items in the array.
-        */
-        ArrayBase.prototype.size = function () {
-            return this._array.length;
-        };
-
-        /**
-        * Returns true if the array is empty.
-        */
-        ArrayBase.prototype.empty = function () {
-            return this._array.length === 0;
-        };
-
-        /**
-        * Returns the item at the given array index.
-        *
-        * @param index The integer index of the desired item.
-        */
-        ArrayBase.prototype.itemAt = function (index) {
-            return this._array[index];
-        };
-
-        /**
-        * Removes and returns the item at the given index.
-        *
-        * @param index The integer index of the desired item.
-        */
-        ArrayBase.prototype.takeAt = function (index) {
-            return this._array.splice(index, 1)[0];
-        };
-
-        /**
-        * Clear the internal contents of array.
-        */
-        ArrayBase.prototype.clear = function () {
-            this._array = [];
-        };
-
-        /**
-        * Swap this array's contents with another array.
-        *
-        * @param other The array base to use for the swap.
-        */
-        ArrayBase.prototype.swap = function (other) {
-            var array = this._array;
-            this._array = other._array;
-            other._array = array;
-        };
-
-        /**
-        * Returns an iterator over the array of items.
-        */
-        ArrayBase.prototype.__iter__ = function () {
-            return iter(this._array);
-        };
-
-        /**
-        * Returns a reverse iterator over the array of items.
-        */
-        ArrayBase.prototype.__reversed__ = function () {
-            return reversed(this._array);
-        };
-        return ArrayBase;
-    })();
-
-    /*-----------------------------------------------------------------------------
-    | Copyright (c) 2014, Nucleic Development Team.
-    |
-    | Distributed under the terms of the Modified BSD License.
-    |
-    | The full license is in the file COPYING.txt, distributed with this software.
-    |----------------------------------------------------------------------------*/
-    var __extends = (undefined && undefined.__extends) || function (d, b) {
-    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
-    function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
-    };
-
-    /**
-    * A mapping container build on a sorted array.
-    *
-    * @class
-    */
-    var AssociativeArray = (function (_super) {
-        __extends(AssociativeArray, _super);
-        /**
-        * Construct a new AssociativeArray.
-        *
-        * @param compare The key comparison function.
-        */
-        function AssociativeArray(compare) {
-            _super.call(this);
-            this._compare = compare;
-            this._wrapped = wrapCompare(compare);
-        }
-        /**
-        * Returns the key comparison function used by this array.
-        */
-        AssociativeArray.prototype.comparitor = function () {
-            return this._compare;
-        };
-
-        /**
-        * Return the array index of the given key, or -1.
-        *
-        * @param key The key to locate in the array.
-        */
-        AssociativeArray.prototype.indexOf = function (key) {
-            return binarySearch(this._array, key, this._wrapped);
-        };
-
-        /**
-        * Returns true if the key is in the array, false otherwise.
-        *
-        * @param key The key to locate in the array.
-        */
-        AssociativeArray.prototype.contains = function (key) {
-            return binarySearch(this._array, key, this._wrapped) >= 0;
-        };
-
-        /**
-        * Returns the pair associated with the given key, or undefined.
-        *
-        * @param key The key to locate in the array.
-        */
-        AssociativeArray.prototype.find = function (key) {
-            return binaryFind(this._array, key, this._wrapped);
-        };
-
-        /**
-        * Returns the pair associated with the key if it exists.
-        *
-        * If the key does not exist, a new pair will be created and
-        * inserted using the value created by the given factory.
-        *
-        * @param key The key to locate in the array.
-        * @param factory The function which creates the default value.
-        */
-        AssociativeArray.prototype.setDefault = function (key, factory) {
-            var array = this._array;
-            var index = lowerBound(array, key, this._wrapped);
-            if (index === array.length) {
-                var pair = new Pair(key, factory());
-                array.push(pair);
-                return pair;
-            }
-            var currPair = array[index];
-            if (this._compare(currPair.first, key) !== 0) {
-                var pair = new Pair(key, factory());
-                array.splice(index, 0, pair);
-                return pair;
-            }
-            return currPair;
-        };
-
-        /**
-        * Insert the pair into the array and return the pair.
-        *
-        * This will overwrite any existing entry in the array.
-        *
-        * @param key The key portion of the pair.
-        * @param value The value portion of the pair.
-        */
-        AssociativeArray.prototype.insert = function (key, value) {
-            var array = this._array;
-            var index = lowerBound(array, key, this._wrapped);
-            if (index === array.length) {
-                var pair = new Pair(key, value);
-                array.push(pair);
-                return pair;
-            }
-            var currPair = array[index];
-            if (this._compare(currPair.first, key) !== 0) {
-                var pair = new Pair(key, value);
-                array.splice(index, 0, pair);
-                return pair;
-            }
-            currPair.second = value;
-            return currPair;
-        };
-
-        AssociativeArray.prototype.update = function (object) {
-            var _this = this;
-            if (object instanceof AssociativeArray) {
-                var obj = object;
-                this._array = merge(this._array, obj._array, this._compare);
-            } else {
-                forEach(object, function (pair) {
-                    _this.insert(pair.first, pair.second);
-                });
-            }
-        };
-
-        /**
-        * Removes and returns the pair for the given key, or undefined.
-        *
-        * @param key The key to remove from the map.
-        */
-        AssociativeArray.prototype.erase = function (key) {
-            var array = this._array;
-            var index = binarySearch(array, key, this._wrapped);
-            if (index < 0) {
-                return undefined;
-            }
-            return array.splice(index, 1)[0];
-        };
-
-        /**
-        * Create a copy of this associative array.
-        */
-        AssociativeArray.prototype.copy = function () {
-            var theCopy = new AssociativeArray(this._compare);
-            var copyArray = theCopy._array;
-            var thisArray = this._array;
-            for (var i = 0, n = thisArray.length; i < n; ++i) {
-                copyArray.push(thisArray[i].copy());
-            }
-            return theCopy;
-        };
-        return AssociativeArray;
-    })(ArrayBase);
-
-    /**
-    * An internal which wraps a comparison key function.
-    */
-    function wrapCompare(cmp) {
-        return function (pair, value) {
-            return cmp(pair.first, value);
-        };
-    }
-
-    /**
-    * An internal function which merges two ordered pair arrays.
-    */
-    function merge(first, second, compare) {
-        var i = 0, j = 0;
-        var len1 = first.length;
-        var len2 = second.length;
-        var merged = [];
-        while (i < len1 && j < len2) {
-            var a = first[i];
-            var b = second[j];
-            var v = compare(a.first, b.first);
-            if (v < 0) {
-                merged.push(a.copy());
-                ++i;
-            } else if (v > 0) {
-                merged.push(b.copy());
-                ++j;
-            } else {
-                merged.push(b.copy());
-                ++i;
-                ++j;
-            }
-        }
-        while (i < len1) {
-            merged.push(first[i].copy());
-            ++i;
-        }
-        while (j < len2) {
-            merged.push(second[j].copy());
-            ++j;
-        }
-        return merged;
-    }
-    /*-----------------------------------------------------------------------------
-    | Copyright (c) 2014, Nucleic Development Team.
-    |
-    | Distributed under the terms of the Modified BSD License.
-    |
-    | The full license is in the file COPYING.txt, distributed with this software.
-    |----------------------------------------------------------------------------*/
-
-    /*-----------------------------------------------------------------------------
-    | Copyright (c) 2014, Nucleic Development Team.
-    |
-    | Distributed under the terms of the Modified BSD License.
-    |
-    | The full license is in the file COPYING.txt, distributed with this software.
-    |----------------------------------------------------------------------------*/
-    function createMap(compare) {
-        return new AssociativeArray(compare);
-    }
+    }());
 
     /*-----------------------------------------------------------------------------
     | Copyright (c) 2014, Nucleic Development Team.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "homepage": "https://github.com/IjzerenHein/kiwi.js",
   "repository": "https://github.com/IjzerenHein/kiwi.js",
   "main": "lib/kiwi.js",
+  "module": "es/kiwi.js",
+  "types": "es/kiwi.d.ts",
   "author": "Chris Colbert <sccolbert@gmail.com>",
   "contributors": {
     "name": "Hein Rutjes <IJzerenHein>"

--- a/package.json
+++ b/package.json
@@ -41,11 +41,13 @@
     "grunt-umd": "^3.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.1.2",
+    "rollup": "^0.65.0",
     "tslint": "^5.9.1",
-    "typescript": "^2.7.2"
+    "typescript": "^3.0.3"
   },
   "scripts": {
     "build": "grunt build",
+    "rollup": "tsc && rollup -c",
     "test": "mocha",
     "cov": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -R test/main",
     "doc": "grunt doc",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,14 @@
+export default {
+	input: 'es/kiwi.js',
+	output: {
+        file: 'lib/kiwi.js',
+        format: 'umd',
+        name: 'kiwi',
+        exports: 'named',
+    },
+    onwarn: function (warning) {
+        // TS emits some helpers with code that causes rollup to carp.  This disables that error.
+        if (warning.code === 'THIS_IS_UNDEFINED') return;
+        console.error(warning.message);
+    }
+}

--- a/src/constraint.ts
+++ b/src/constraint.ts
@@ -7,7 +7,7 @@
 |----------------------------------------------------------------------------*/
 
 import { Expression } from "./expression";
-import * as Strength from "./strength";
+import { Strength } from "./strength";
 import { Variable } from "./variable";
 
 /**

--- a/src/constraint.ts
+++ b/src/constraint.ts
@@ -6,8 +6,9 @@
 | The full license is in the file COPYING.txt, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-// <reference path="expression.ts">
-// <reference path="strength.ts">
+import { Expression } from "./expression";
+import * as Strength from "./strength";
+import { Variable } from "./variable";
 
 /**
  * Kiwi is an efficient implementation of the Cassowary constraint solving
@@ -46,110 +47,108 @@
  * ##API Documentation
  * @module kiwi
  */
-namespace kiwi {
-    /**
-     * An enum defining the linear constraint operators.
-     *
-     * |Value|Operator|Description|
-     * |----|-----|-----|
-     * |`Le`|<=|Less than equal|
-     * |`Ge`|>=|Greater than equal|
-     * |`Eq`|==|Equal|
-     *
-     * @enum {Number}
-     */
-    export
-    enum Operator {
-        Le,  // <=
-        Ge,  // >=
-        Eq,   // ==
+
+/**
+ * An enum defining the linear constraint operators.
+ *
+ * |Value|Operator|Description|
+ * |----|-----|-----|
+ * |`Le`|<=|Less than equal|
+ * |`Ge`|>=|Greater than equal|
+ * |`Eq`|==|Equal|
+ *
+ * @enum {Number}
+ */
+export
+enum Operator {
+    Le,  // <=
+    Ge,  // >=
+    Eq,   // ==
+}
+
+/**
+ * A linear constraint equation.
+ *
+ * A constraint equation is composed of an expression, an operator,
+ * and a strength. The RHS of the equation is implicitly zero.
+ *
+ * @class
+ * @param {Expression} expression The constraint expression (LHS).
+ * @param {Operator} operator The equation operator.
+ * @param {Expression} [rhs] Right hand side of the expression.
+ * @param {Number} [strength=Strength.required] The strength of the constraint.
+ */
+export
+class Constraint {
+    constructor(
+        expression: Expression|Variable,
+        operator: Operator,
+        rhs?: Expression|Variable|number,
+        strength: number = Strength.required) {
+        this._operator = operator;
+        this._strength = Strength.clip(strength);
+        if ((rhs === undefined) && (expression instanceof Expression)) {
+            this._expression = expression;
+        } else {
+            this._expression = expression.minus(rhs);
+        }
     }
 
     /**
-     * A linear constraint equation.
-     *
-     * A constraint equation is composed of an expression, an operator,
-     * and a strength. The RHS of the equation is implicitly zero.
-     *
-     * @class
-     * @param {Expression} expression The constraint expression (LHS).
-     * @param {Operator} operator The equation operator.
-     * @param {Expression} [rhs] Right hand side of the expression.
-     * @param {Number} [strength=Strength.required] The strength of the constraint.
-     */
-    export
-    class Constraint {
-        constructor(
-            expression: Expression|Variable,
-            operator: Operator,
-            rhs?: Expression|Variable|number,
-            strength: number = Strength.required) {
-            this._operator = operator;
-            this._strength = Strength.clip(strength);
-            if ((rhs === undefined) && (expression instanceof Expression)) {
-                this._expression = expression;
-            } else {
-                this._expression = expression.minus(rhs);
-            }
-        }
-
-       /**
-         * A static constraint comparison function.
-         * @private
-         */
-        public static Compare( a: Constraint, b: Constraint ): number {
-            return a.id() - b.id();
-        }
-
-        /**
-         * Returns the unique id number of the constraint.
-         * @private
-         */
-        public id(): number {
-            return this._id;
-        }
-
-        /**
-         * Returns the expression of the constraint.
-         *
-         * @return {Expression} expression
-         */
-        public expression(): Expression {
-            return this._expression;
-        }
-
-        /**
-         * Returns the relational operator of the constraint.
-         *
-         * @return {Operator} linear constraint operator
-         */
-        public op(): Operator {
-            return this._operator;
-        }
-
-        /**
-         * Returns the strength of the constraint.
-         *
-         * @return {Number} strength
-         */
-        public strength(): number {
-            return this._strength;
-        }
-
-        public toString(): string {
-            return this._expression.toString() + " " + ["<=", ">=", "="][this._operator] + " 0 (" + this._strength.toString() + ")";
-        }
-
-        private _expression: Expression;
-        private _operator: Operator;
-        private _strength: number;
-        private _id: number = CnId++;
-    }
-
-    /**
-     * The internal constraint id counter.
+     * A static constraint comparison function.
      * @private
      */
-    let CnId = 0;
+    public static Compare( a: Constraint, b: Constraint ): number {
+        return a.id() - b.id();
+    }
 
+    /**
+     * Returns the unique id number of the constraint.
+     * @private
+     */
+    public id(): number {
+        return this._id;
+    }
+
+    /**
+     * Returns the expression of the constraint.
+     *
+     * @return {Expression} expression
+     */
+    public expression(): Expression {
+        return this._expression;
+    }
+
+    /**
+     * Returns the relational operator of the constraint.
+     *
+     * @return {Operator} linear constraint operator
+     */
+    public op(): Operator {
+        return this._operator;
+    }
+
+    /**
+     * Returns the strength of the constraint.
+     *
+     * @return {Number} strength
+     */
+    public strength(): number {
+        return this._strength;
+    }
+
+    public toString(): string {
+        return this._expression.toString() + " " + ["<=", ">=", "="][this._operator] + " 0 (" + this._strength.toString() + ")";
+    }
+
+    private _expression: Expression;
+    private _operator: Operator;
+    private _strength: number;
+    private _id: number = CnId++;
 }
+
+/**
+ * The internal constraint id counter.
+ * @private
+ */
+let CnId = 0;

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -6,188 +6,183 @@
 | The full license is in the file COPYING.txt, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-/// <reference path="../thirdparty/tsu.d.ts"/>
-/// <reference path="maptype.ts"/>
-/// <reference path="variable.ts"/>
+import { createMap, IMap } from "./maptype";
+import { Variable } from "./variable";
 
-namespace kiwi {
-
-    /**
-     * An expression of variable terms and a constant.
-     *
-     * The constructor accepts an arbitrary number of parameters,
-     * each of which must be one of the following types:
-     *  - number
-     *  - Variable
-     *  - Expression
-     *  - 2-tuple of [number, Variable|Expression]
-     *
-     * The parameters are summed. The tuples are multiplied.
-     *
-     * @class
-     * @param {...(number|Variable|Expression|Array)} args
-     */
-    export
-    class Expression {
-        constructor( ...args: any[] );
-        constructor() {
-            let parsed = parseArgs( arguments );
-            this._terms = parsed.terms;
-            this._constant = parsed.constant;
-        }
-
-        /**
-         * Returns the mapping of terms in the expression.
-         *
-         * This *must* be treated as const.
-         * @private
-         */
-        public terms(): IMap<Variable, number> {
-            return this._terms;
-        }
-
-        /**
-         * Returns the constant of the expression.
-         * @private
-         */
-        public constant(): number {
-            return this._constant;
-        }
-
-        /**
-         * Returns the computed value of the expression.
-         *
-         * @private
-         * @return {Number} computed value of the expression
-         */
-        public value(): number {
-            let result = this._constant;
-            for ( let i = 0, n = this._terms.size(); i < n; i++ ) {
-                let pair = this._terms.itemAt(i);
-                result += pair.first.value() * pair.second;
-            }
-            return result;
-        }
-
-        /**
-         * Creates a new Expression by adding a number, variable or expression
-         * to the expression.
-         *
-         * @param {Number|Variable|Expression} value Value to add.
-         * @return {Expression} expression
-         */
-        public plus( value: number|Variable|Expression ): Expression {
-            return new Expression(this, value);
-        }
-
-        /**
-         * Creates a new Expression by substracting a number, variable or expression
-         * from the expression.
-         *
-         * @param {Number|Variable|Expression} value Value to substract.
-         * @return {Expression} expression
-         */
-        public minus( value: number|Variable|Expression ): Expression {
-            return new Expression(this, typeof value === "number" ? -value : [-1, value]);
-        }
-
-        /**
-         * Creates a new Expression by multiplying with a fixed number.
-         *
-         * @param {Number} coefficient Coefficient to multiply with.
-         * @return {Expression} expression
-         */
-        public multiply( coefficient: number ): Expression {
-            return new Expression([coefficient, this]);
-        }
-
-        /**
-         * Creates a new Expression by dividing with a fixed number.
-         *
-         * @param {Number} coefficient Coefficient to divide by.
-         * @return {Expression} expression
-         */
-        public divide( coefficient: number ): Expression {
-            return new Expression([1 / coefficient, this]);
-        }
-
-        public isConstant(): boolean {
-            return this._terms.size() == 0;
-        }
-
-        public toString(): string {
-            let result = this._terms._array.map(function(pair, idx) {
-                return (pair.second + "*" + pair.first.toString());
-            }).join(" + ");
-
-            if (!this.isConstant() && this._constant !== 0) {
-                result += " + ";
-            }
-
-            result += this._constant;
-
-            return result;
-        }
-
-        private _terms: IMap<Variable, number>;
-        private _constant: number;
+/**
+ * An expression of variable terms and a constant.
+ *
+ * The constructor accepts an arbitrary number of parameters,
+ * each of which must be one of the following types:
+ *  - number
+ *  - Variable
+ *  - Expression
+ *  - 2-tuple of [number, Variable|Expression]
+ *
+ * The parameters are summed. The tuples are multiplied.
+ *
+ * @class
+ * @param {...(number|Variable|Expression|Array)} args
+ */
+export
+class Expression {
+    constructor( ...args: any[] );
+    constructor() {
+        let parsed = parseArgs( arguments );
+        this._terms = parsed.terms;
+        this._constant = parsed.constant;
     }
 
     /**
-     * An internal interface for the argument parse results.
-     */
-    interface IParseResult {
-        terms: IMap<Variable, number>;
-        constant: number;
-    }
-
-    /**
-     * An internal argument parsing function.
+     * Returns the mapping of terms in the expression.
+     *
+     * This *must* be treated as const.
      * @private
      */
-    function parseArgs( args: IArguments ): IParseResult {
-        let constant = 0.0;
-        let factory = () => 0.0;
-        let terms = createMap<Variable, number>( Variable.Compare );
-        for ( let i = 0, n = args.length; i < n; ++i ) {
-            let item = args[ i ];
-            if ( typeof item === "number" ) {
-                constant += item;
-            } else if ( item instanceof Variable ) {
-                terms.setDefault( item, factory ).second += 1.0;
-            } else if (item instanceof Expression) {
-                constant += item.constant();
-                let terms2 = item.terms();
-                for (let j = 0, k = terms2.size(); j < k; j++) {
-                    let termPair = terms2.itemAt(j);
-                    terms.setDefault(termPair.first, factory).second += termPair.second;
-                }
-            } else if ( item instanceof Array ) {
-                if ( item.length !== 2 ) {
-                    throw new Error( "array must have length 2" );
-                }
-                let value: number = item[ 0 ];
-                let value2 = item[ 1 ];
-                if ( typeof value !== "number" ) {
-                    throw new Error( "array item 0 must be a number" );
-                }
-                if (value2 instanceof Variable) {
-                    terms.setDefault(value2, factory).second += value;
-                } else if (value2 instanceof Expression) {
-                    constant += (value2.constant() * value);
-                    let terms2 = value2.terms();
-                    for (let j = 0, k = terms2.size(); j < k; j++) {
-                        let termPair = terms2.itemAt(j);
-                        terms.setDefault(termPair.first, factory).second += (termPair.second * value);
-                    }
-                } else {
-                    throw new Error("array item 1 must be a variable or expression");
-                }
-            } else {
-                throw new Error( "invalid Expression argument: " + item );
-            }
-        }
-        return { terms, constant };
+    public terms(): IMap<Variable, number> {
+        return this._terms;
     }
 
+    /**
+     * Returns the constant of the expression.
+     * @private
+     */
+    public constant(): number {
+        return this._constant;
+    }
+
+    /**
+     * Returns the computed value of the expression.
+     *
+     * @private
+     * @return {Number} computed value of the expression
+     */
+    public value(): number {
+        let result = this._constant;
+        for ( let i = 0, n = this._terms.size(); i < n; i++ ) {
+            let pair = this._terms.itemAt(i);
+            result += pair.first.value() * pair.second;
+        }
+        return result;
+    }
+
+    /**
+     * Creates a new Expression by adding a number, variable or expression
+     * to the expression.
+     *
+     * @param {Number|Variable|Expression} value Value to add.
+     * @return {Expression} expression
+     */
+    public plus( value: number|Variable|Expression ): Expression {
+        return new Expression(this, value);
+    }
+
+    /**
+     * Creates a new Expression by substracting a number, variable or expression
+     * from the expression.
+     *
+     * @param {Number|Variable|Expression} value Value to substract.
+     * @return {Expression} expression
+     */
+    public minus( value: number|Variable|Expression ): Expression {
+        return new Expression(this, typeof value === "number" ? -value : [-1, value]);
+    }
+
+    /**
+     * Creates a new Expression by multiplying with a fixed number.
+     *
+     * @param {Number} coefficient Coefficient to multiply with.
+     * @return {Expression} expression
+     */
+    public multiply( coefficient: number ): Expression {
+        return new Expression([coefficient, this]);
+    }
+
+    /**
+     * Creates a new Expression by dividing with a fixed number.
+     *
+     * @param {Number} coefficient Coefficient to divide by.
+     * @return {Expression} expression
+     */
+    public divide( coefficient: number ): Expression {
+        return new Expression([1 / coefficient, this]);
+    }
+
+    public isConstant(): boolean {
+        return this._terms.size() == 0;
+    }
+
+    public toString(): string {
+        let result = this._terms._array.map(function(pair, idx) {
+            return (pair.second + "*" + pair.first.toString());
+        }).join(" + ");
+
+        if (!this.isConstant() && this._constant !== 0) {
+            result += " + ";
+        }
+
+        result += this._constant;
+
+        return result;
+    }
+
+    private _terms: IMap<Variable, number>;
+    private _constant: number;
+}
+
+/**
+ * An internal interface for the argument parse results.
+ */
+interface IParseResult {
+    terms: IMap<Variable, number>;
+    constant: number;
+}
+
+/**
+ * An internal argument parsing function.
+ * @private
+ */
+function parseArgs( args: IArguments ): IParseResult {
+    let constant = 0.0;
+    let factory = () => 0.0;
+    let terms = createMap<Variable, number>( Variable.Compare );
+    for ( let i = 0, n = args.length; i < n; ++i ) {
+        let item = args[ i ];
+        if ( typeof item === "number" ) {
+            constant += item;
+        } else if ( item instanceof Variable ) {
+            terms.setDefault( item, factory ).second += 1.0;
+        } else if (item instanceof Expression) {
+            constant += item.constant();
+            let terms2 = item.terms();
+            for (let j = 0, k = terms2.size(); j < k; j++) {
+                let termPair = terms2.itemAt(j);
+                terms.setDefault(termPair.first, factory).second += termPair.second;
+            }
+        } else if ( item instanceof Array ) {
+            if ( item.length !== 2 ) {
+                throw new Error( "array must have length 2" );
+            }
+            let value: number = item[ 0 ];
+            let value2 = item[ 1 ];
+            if ( typeof value !== "number" ) {
+                throw new Error( "array item 0 must be a number" );
+            }
+            if (value2 instanceof Variable) {
+                terms.setDefault(value2, factory).second += value;
+            } else if (value2 instanceof Expression) {
+                constant += (value2.constant() * value);
+                let terms2 = value2.terms();
+                for (let j = 0, k = terms2.size(); j < k; j++) {
+                    let termPair = terms2.itemAt(j);
+                    terms.setDefault(termPair.first, factory).second += (termPair.second * value);
+                }
+            } else {
+                throw new Error("array item 1 must be a variable or expression");
+            }
+        } else {
+            throw new Error( "invalid Expression argument: " + item );
+        }
+    }
+    return { terms, constant };
 }

--- a/src/kiwi.ts
+++ b/src/kiwi.ts
@@ -6,11 +6,10 @@
 | The full license is in the file COPYING.txt, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-/// <reference path="constraint.ts"/>
-/// <reference path="expression.ts"/>
-/// <reference path="maptype.ts"/>
-/// <reference path="solver.ts"/>
-/// <reference path="strength.ts"/>
-/// <reference path="variable.ts"/>
-
-namespace kiwi { }
+export * from "./constraint";
+export * from "./expression";
+export * from "./maptype";
+export * from "./solver";
+import * as Stength from "./strength";
+export { Stength };
+export * from "./variable";

--- a/src/kiwi.ts
+++ b/src/kiwi.ts
@@ -10,6 +10,5 @@ export * from "./constraint";
 export * from "./expression";
 export * from "./maptype";
 export * from "./solver";
-import * as Stength from "./strength";
-export { Stength };
+export * from "./strength";
 export * from "./variable";

--- a/src/maptype.ts
+++ b/src/maptype.ts
@@ -6,12 +6,143 @@
 | The full license is in the file COPYING.txt, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-import * as tsu from "../thirdparty/tsu";
+export interface IMap<T extends { id(): number }, U> extends IndexedMap<T, U> { }
 
 export
-interface IMap<T, U> extends tsu.AssociativeArray<T, U> { }
+function createMap<T extends { id() : number }, U>( compare: any ): IMap<T, U> {
+    return new IndexedMap<T, U>();
+}
 
-export
-function createMap<T, U>( compare: tsu.ICompare<T, T> ): IMap<T, U> {
-    return new tsu.AssociativeArray<T, U>( compare );
+class IndexedMap<T extends { id() : number }, U> {
+    public _index = {} as { [ id : number ] : number | undefined };
+    public _array = [] as Pair<T, U>[];
+    
+    /**
+     * Returns the number of items in the array.
+     */
+    public size(): number {
+        return this._array.length;
+    }
+
+    /**
+    * Returns true if the array is empty.
+    */
+    public empty(): boolean {
+        return this._array.length === 0;
+    }
+    
+    /**
+     * Returns the item at the given array index.
+     *
+     * @param index The integer index of the desired item.
+     */
+    public itemAt(index: number): Pair<T, U> {
+        return this._array[index];
+    }
+
+    /**
+    * Returns true if the key is in the array, false otherwise.
+    *
+    * @param key The key to locate in the array.
+    */
+    public contains(key: T) {
+        return this._index[key.id()] !== undefined;
+    }
+
+    /**
+     * Returns the pair associated with the given key, or undefined.
+     *
+     * @param key The key to locate in the array.
+     */
+    public find(key: T) {
+        const i = this._index[key.id()];
+        return i === undefined ? undefined : this._array[i];
+    }
+
+    /**
+     * Returns the pair associated with the key if it exists.
+     *
+     * If the key does not exist, a new pair will be created and
+     * inserted using the value created by the given factory.
+     *
+     * @param key The key to locate in the array.
+     * @param factory The function which creates the default value.
+     */
+    public setDefault(key: T, factory: () => U): Pair<T, U> {
+        const i = this._index[key.id()];
+        if (i === undefined) {
+            const pair = new Pair(key, factory());
+            this._index[key.id()] = this._array.length;
+            this._array.push(pair);
+            return pair;
+        } else {
+            return this._array[i];
+        }
+    }
+
+    /**
+     * Insert the pair into the array and return the pair.
+     *
+     * This will overwrite any existing entry in the array.
+     *
+     * @param key The key portion of the pair.
+     * @param value The value portion of the pair.
+     */
+    public insert(key: T, value: U): Pair<T, U> {
+        const pair = new Pair(key, value),
+            i = this._index[key.id()];
+        if (i === undefined) {
+            this._index[key.id()] = this._array.length;
+            this._array.push(pair);
+        } else {
+            this._array[i] = pair;
+        }
+        return pair;
+    }
+
+    /**
+     * Removes and returns the pair for the given key, or undefined.
+     *
+     * @param key The key to remove from the map.
+     */
+    public erase(key: T): Pair<T, U> {
+        const i = this._index[key.id()];
+        if (i === undefined) return undefined;
+        this._index[key.id()] = undefined;
+        const pair = this._array[i],
+            last = this._array.pop();
+        if (pair !== last) {
+            this._array[i] = last;
+            this._index[last.first.id()] = i;
+        }
+        return pair;
+    }
+
+    /**
+     * Create a copy of this associative array.
+     */
+    public copy(): IndexedMap<T, U> {
+        const copy = new IndexedMap<T, U>();
+        copy._index = { ...this._index };
+        copy._array = this._array.map(p => p.copy());
+        return copy;
+    }
+}
+
+/**
+* A class which defines a generic pair object.
+*/
+class Pair<T, U> {
+    /**
+    * Construct a new Pair object.
+    *
+    * @param first The first item of the pair.
+    * @param second The second item of the pair.
+    */
+    constructor(public first: T, public second: U) { }
+
+    /**
+    * Create a copy of the pair.
+    */
+    public copy() { return new Pair(this.first, this.second); }
 }

--- a/src/maptype.ts
+++ b/src/maptype.ts
@@ -6,16 +6,12 @@
 | The full license is in the file COPYING.txt, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-/// <reference path="../thirdparty/tsu.d.ts"/>
+import * as tsu from "../thirdparty/tsu";
 
-namespace kiwi {
+export
+interface IMap<T, U> extends tsu.AssociativeArray<T, U> { }
 
-    export
-    interface IMap<T, U> extends tsu.AssociativeArray<T, U> { }
-
-    export
-    function createMap<T, U>( compare: tsu.ICompare<T, T> ): IMap<T, U> {
-        return new tsu.AssociativeArray<T, U>( compare );
-    }
-
+export
+function createMap<T, U>( compare: tsu.ICompare<T, T> ): IMap<T, U> {
+    return new tsu.AssociativeArray<T, U>( compare );
 }

--- a/src/solver.ts
+++ b/src/solver.ts
@@ -9,7 +9,7 @@
 import { Constraint, Operator } from "./constraint";
 import { Expression } from "./expression";
 import { createMap, IMap } from "./maptype";
-import * as Strength from "./strength";
+import { Strength } from "./strength";
 import { Variable } from "./variable";
 
 /**

--- a/src/solver.ts
+++ b/src/solver.ts
@@ -6,1042 +6,1037 @@
 | The full license is in the file COPYING.txt, distributed with this software.
 |----------------------------------------------------------------------------*/
 
-/// <reference path="../thirdparty/tsu.d.ts"/>
-/// <reference path="constraint.ts"/>
-/// <reference path="expression.ts"/>
-/// <reference path="maptype.ts"/>
-/// <reference path="strength.ts"/>
-/// <reference path="variable.ts"/>
+import { Constraint, Operator } from "./constraint";
+import { Expression } from "./expression";
+import { createMap, IMap } from "./maptype";
+import * as Strength from "./strength";
+import { Variable } from "./variable";
 
-namespace kiwi {
+/**
+ * The constraint solver class.
+ *
+ * @class
+ */
+export
+class Solver {
+    /**
+     * Construct a new Solver.
+     */
+    constructor() { }
 
     /**
-     * The constraint solver class.
+     * Creates and add a constraint to the solver.
      *
-     * @class
+     * @param {Expression|Variable} lhs Left hand side of the expression
+     * @param {Operator} operator Operator
+     * @param {Expression|Variable|Number} rhs Right hand side of the expression
+     * @param {Number} [strength=Strength.required] Strength
      */
-    export
-    class Solver {
-        /**
-         * Construct a new Solver.
-         */
-        constructor() { }
+    public createConstraint(
+        lhs: Expression|Variable,
+        operator: Operator,
+        rhs: Expression|Variable|number,
+        strength: number = Strength.required): Constraint {
+        let cn = new Constraint(lhs, operator, rhs, strength);
+        this.addConstraint(cn);
+        return cn;
+    }
 
-        /**
-         * Creates and add a constraint to the solver.
-         *
-         * @param {Expression|Variable} lhs Left hand side of the expression
-         * @param {Operator} operator Operator
-         * @param {Expression|Variable|Number} rhs Right hand side of the expression
-         * @param {Number} [strength=Strength.required] Strength
-         */
-        public createConstraint(
-            lhs: Expression|Variable,
-            operator: Operator,
-            rhs: Expression|Variable|number,
-            strength: number = Strength.required): Constraint {
-            let cn = new Constraint(lhs, operator, rhs, strength);
-            this.addConstraint(cn);
-            return cn;
+    /**
+     * Add a constraint to the solver.
+     *
+     * @param {Constraint} constraint Constraint to add to the solver
+     */
+    public addConstraint(constraint: Constraint): void {
+        let cnPair = this._cnMap.find(constraint);
+        if (cnPair !== undefined) {
+            throw new Error("duplicate constraint");
         }
 
-        /**
-         * Add a constraint to the solver.
-         *
-         * @param {Constraint} constraint Constraint to add to the solver
-         */
-        public addConstraint(constraint: Constraint): void {
-            let cnPair = this._cnMap.find(constraint);
-            if (cnPair !== undefined) {
-                throw new Error("duplicate constraint");
-            }
+        // Creating a row causes symbols to be reserved for the variables
+        // in the constraint. If this method exits with an exception,
+        // then its possible those variables will linger in the var map.
+        // Since its likely that those variables will be used in other
+        // constraints and since exceptional conditions are uncommon,
+        // i'm not too worried about aggressive cleanup of the var map.
+        let data = this._createRow( constraint );
+        let row = data.row;
+        let tag = data.tag;
+        let subject = this._chooseSubject( row, tag );
 
-            // Creating a row causes symbols to be reserved for the variables
-            // in the constraint. If this method exits with an exception,
-            // then its possible those variables will linger in the var map.
-            // Since its likely that those variables will be used in other
-            // constraints and since exceptional conditions are uncommon,
-            // i'm not too worried about aggressive cleanup of the var map.
-            let data = this._createRow( constraint );
-            let row = data.row;
-            let tag = data.tag;
-            let subject = this._chooseSubject( row, tag );
-
-            // If chooseSubject couldnt find a valid entering symbol, one
-            // last option is available if the entire row is composed of
-            // dummy variables. If the constant of the row is zero, then
-            // this represents redundant constraints and the new dummy
-            // marker can enter the basis. If the constant is non-zero,
-            // then it represents an unsatisfiable constraint.
-            if ( subject.type() === SymbolType.Invalid && row.allDummies() ) {
-                if ( !nearZero( row.constant() ) ) {
-                    throw new Error( "unsatisfiable constraint" );
-                } else {
-                    subject = tag.marker;
-                }
-            }
-
-            // If an entering symbol still isn't found, then the row must
-            // be added using an artificial variable. If that fails, then
-            // the row represents an unsatisfiable constraint.
-            if ( subject.type() === SymbolType.Invalid ) {
-                if ( !this._addWithArtificialVariable( row ) ) {
-                    throw new Error( "unsatisfiable constraint" );
-                }
+        // If chooseSubject couldnt find a valid entering symbol, one
+        // last option is available if the entire row is composed of
+        // dummy variables. If the constant of the row is zero, then
+        // this represents redundant constraints and the new dummy
+        // marker can enter the basis. If the constant is non-zero,
+        // then it represents an unsatisfiable constraint.
+        if ( subject.type() === SymbolType.Invalid && row.allDummies() ) {
+            if ( !nearZero( row.constant() ) ) {
+                throw new Error( "unsatisfiable constraint" );
             } else {
-                row.solveFor( subject );
-                this._substitute( subject, row );
-                this._rowMap.insert( subject, row );
+                subject = tag.marker;
             }
-
-            this._cnMap.insert( constraint, tag );
-
-            // Optimizing after each constraint is added performs less
-            // aggregate work due to a smaller average system size. It
-            // also ensures the solver remains in a consistent state.
-            this._optimize( this._objective );
         }
 
-        /**
-         * Remove a constraint from the solver.
-         *
-         * @param {Constraint} constraint Constraint to remove from the solver
-         */
-        public removeConstraint( constraint: Constraint ): void {
-            let cnPair = this._cnMap.erase( constraint );
-            if ( cnPair === undefined ) {
-                throw new Error( "unknown constraint" );
+        // If an entering symbol still isn't found, then the row must
+        // be added using an artificial variable. If that fails, then
+        // the row represents an unsatisfiable constraint.
+        if ( subject.type() === SymbolType.Invalid ) {
+            if ( !this._addWithArtificialVariable( row ) ) {
+                throw new Error( "unsatisfiable constraint" );
             }
-
-            // Remove the error effects from the objective function
-            // *before* pivoting, or substitutions into the objective
-            // will lead to incorrect solver results.
-            this._removeConstraintEffects( constraint, cnPair.second );
-
-            // If the marker is basic, simply drop the row. Otherwise,
-            // pivot the marker into the basis and then drop the row.
-            let marker = cnPair.second.marker;
-            let rowPair = this._rowMap.erase( marker );
-            if ( rowPair === undefined ) {
-                let leaving = this._getMarkerLeavingSymbol( marker );
-                if ( leaving.type() === SymbolType.Invalid ) {
-                    throw new Error( "failed to find leaving row" );
-                }
-                rowPair = this._rowMap.erase( leaving );
-                rowPair.second.solveForEx( leaving, marker );
-                this._substitute( marker, rowPair.second );
-            }
-
-            // Optimizing after each constraint is removed ensures that the
-            // solver remains consistent. It makes the solver api easier to
-            // use at a small tradeoff for speed.
-            this._optimize( this._objective );
+        } else {
+            row.solveFor( subject );
+            this._substitute( subject, row );
+            this._rowMap.insert( subject, row );
         }
 
-        /**
-         * Test whether the solver contains the constraint.
-         *
-         * @param {Constraint} constraint Constraint to test for
-         * @return {Bool} true or false
-         */
-        public hasConstraint( constraint: Constraint ): boolean {
-            return this._cnMap.contains( constraint );
+        this._cnMap.insert( constraint, tag );
+
+        // Optimizing after each constraint is added performs less
+        // aggregate work due to a smaller average system size. It
+        // also ensures the solver remains in a consistent state.
+        this._optimize( this._objective );
+    }
+
+    /**
+     * Remove a constraint from the solver.
+     *
+     * @param {Constraint} constraint Constraint to remove from the solver
+     */
+    public removeConstraint( constraint: Constraint ): void {
+        let cnPair = this._cnMap.erase( constraint );
+        if ( cnPair === undefined ) {
+            throw new Error( "unknown constraint" );
         }
 
-        /**
-         * Add an edit variable to the solver.
-         *
-         * @param {Variable} variable Edit variable to add to the solver
-         * @param {Number} strength Strength, should be less than `Strength.required`
-         */
-        public addEditVariable( variable: Variable, strength: number ): void {
-            let editPair = this._editMap.find( variable );
-            if ( editPair !== undefined ) {
-                throw new Error( "duplicate edit variable" );
+        // Remove the error effects from the objective function
+        // *before* pivoting, or substitutions into the objective
+        // will lead to incorrect solver results.
+        this._removeConstraintEffects( constraint, cnPair.second );
+
+        // If the marker is basic, simply drop the row. Otherwise,
+        // pivot the marker into the basis and then drop the row.
+        let marker = cnPair.second.marker;
+        let rowPair = this._rowMap.erase( marker );
+        if ( rowPair === undefined ) {
+            let leaving = this._getMarkerLeavingSymbol( marker );
+            if ( leaving.type() === SymbolType.Invalid ) {
+                throw new Error( "failed to find leaving row" );
             }
-            strength = Strength.clip( strength );
-            if ( strength === Strength.required ) {
-                throw new Error( "bad required strength" );
-            }
-            let expr = new Expression( variable );
-            let cn = new Constraint( expr, Operator.Eq, undefined, strength );
-            this.addConstraint( cn );
-            let tag = this._cnMap.find( cn ).second;
-            let info = { tag, constraint: cn, constant: 0.0 };
-            this._editMap.insert( variable, info );
+            rowPair = this._rowMap.erase( leaving );
+            rowPair.second.solveForEx( leaving, marker );
+            this._substitute( marker, rowPair.second );
         }
 
-        /**
-         * Remove an edit variable from the solver.
-         *
-         * @param {Variable} variable Edit variable to remove from the solver
-         */
-        public removeEditVariable( variable: Variable ): void {
-            let editPair = this._editMap.erase( variable );
-            if ( editPair === undefined ) {
-                throw new Error( "unknown edit variable" );
-            }
-            this.removeConstraint( editPair.second.constraint );
+        // Optimizing after each constraint is removed ensures that the
+        // solver remains consistent. It makes the solver api easier to
+        // use at a small tradeoff for speed.
+        this._optimize( this._objective );
+    }
+
+    /**
+     * Test whether the solver contains the constraint.
+     *
+     * @param {Constraint} constraint Constraint to test for
+     * @return {Bool} true or false
+     */
+    public hasConstraint( constraint: Constraint ): boolean {
+        return this._cnMap.contains( constraint );
+    }
+
+    /**
+     * Add an edit variable to the solver.
+     *
+     * @param {Variable} variable Edit variable to add to the solver
+     * @param {Number} strength Strength, should be less than `Strength.required`
+     */
+    public addEditVariable( variable: Variable, strength: number ): void {
+        let editPair = this._editMap.find( variable );
+        if ( editPair !== undefined ) {
+            throw new Error( "duplicate edit variable" );
+        }
+        strength = Strength.clip( strength );
+        if ( strength === Strength.required ) {
+            throw new Error( "bad required strength" );
+        }
+        let expr = new Expression( variable );
+        let cn = new Constraint( expr, Operator.Eq, undefined, strength );
+        this.addConstraint( cn );
+        let tag = this._cnMap.find( cn ).second;
+        let info = { tag, constraint: cn, constant: 0.0 };
+        this._editMap.insert( variable, info );
+    }
+
+    /**
+     * Remove an edit variable from the solver.
+     *
+     * @param {Variable} variable Edit variable to remove from the solver
+     */
+    public removeEditVariable( variable: Variable ): void {
+        let editPair = this._editMap.erase( variable );
+        if ( editPair === undefined ) {
+            throw new Error( "unknown edit variable" );
+        }
+        this.removeConstraint( editPair.second.constraint );
+    }
+
+    /**
+     * Test whether the solver contains the edit variable.
+     *
+     * @param {Variable} variable Edit variable to test for
+     * @return {Bool} true or false
+     */
+    public hasEditVariable( variable: Variable ): boolean {
+        return this._editMap.contains( variable );
+    }
+
+    /**
+     * Suggest the value of an edit variable.
+     *
+     * @param {Variable} variable Edit variable to suggest a value for
+     * @param {Number} value Suggested value
+     */
+    public suggestValue( variable: Variable, value: number ): void {
+        let editPair = this._editMap.find( variable );
+        if ( editPair === undefined ) {
+            throw new Error( "unknown edit variable" );
         }
 
-        /**
-         * Test whether the solver contains the edit variable.
-         *
-         * @param {Variable} variable Edit variable to test for
-         * @return {Bool} true or false
-         */
-        public hasEditVariable( variable: Variable ): boolean {
-            return this._editMap.contains( variable );
-        }
+        let rows = this._rowMap;
+        let info = editPair.second;
+        let delta = value - info.constant;
+        info.constant = value;
 
-        /**
-         * Suggest the value of an edit variable.
-         *
-         * @param {Variable} variable Edit variable to suggest a value for
-         * @param {Number} value Suggested value
-         */
-        public suggestValue( variable: Variable, value: number ): void {
-            let editPair = this._editMap.find( variable );
-            if ( editPair === undefined ) {
-                throw new Error( "unknown edit variable" );
-            }
-
-            let rows = this._rowMap;
-            let info = editPair.second;
-            let delta = value - info.constant;
-            info.constant = value;
-
-            // Check first if the positive error variable is basic.
-            let marker = info.tag.marker;
-            let rowPair = rows.find( marker );
-            if ( rowPair !== undefined ) {
-                if ( rowPair.second.add( -delta ) < 0.0 ) {
-                    this._infeasibleRows.push( marker );
-                }
-                this._dualOptimize();
-                return;
-            }
-
-            // Check next if the negative error variable is basic.
-            let other = info.tag.other;
-            rowPair = rows.find( other );
-            if ( rowPair !== undefined ) {
-                if ( rowPair.second.add( delta ) < 0.0 ) {
-                    this._infeasibleRows.push( other );
-                }
-                this._dualOptimize();
-                return;
-            }
-
-            // Otherwise update each row where the error variables exist.
-            for ( let i = 0, n = rows.size(); i < n; ++i ) {
-                let rowPair = rows.itemAt( i );
-                let row = rowPair.second;
-                let coeff = row.coefficientFor( marker );
-                if ( coeff !== 0.0 && row.add( delta * coeff ) < 0.0 &&
-                    rowPair.first.type() !== SymbolType.External ) {
-                    this._infeasibleRows.push( rowPair.first );
-                }
+        // Check first if the positive error variable is basic.
+        let marker = info.tag.marker;
+        let rowPair = rows.find( marker );
+        if ( rowPair !== undefined ) {
+            if ( rowPair.second.add( -delta ) < 0.0 ) {
+                this._infeasibleRows.push( marker );
             }
             this._dualOptimize();
+            return;
         }
 
-        /**
-         * Update the values of the variables.
-         */
-        public updateVariables(): void {
-            let vars = this._varMap;
-            let rows = this._rowMap;
-            for ( let i = 0, n = vars.size(); i < n; ++i ) {
-                let pair = vars.itemAt( i );
-                let rowPair = rows.find( pair.second );
-                if ( rowPair !== undefined ) {
-                    pair.first.setValue( rowPair.second.constant() );
+        // Check next if the negative error variable is basic.
+        let other = info.tag.other;
+        rowPair = rows.find( other );
+        if ( rowPair !== undefined ) {
+            if ( rowPair.second.add( delta ) < 0.0 ) {
+                this._infeasibleRows.push( other );
+            }
+            this._dualOptimize();
+            return;
+        }
+
+        // Otherwise update each row where the error variables exist.
+        for ( let i = 0, n = rows.size(); i < n; ++i ) {
+            let rowPair = rows.itemAt( i );
+            let row = rowPair.second;
+            let coeff = row.coefficientFor( marker );
+            if ( coeff !== 0.0 && row.add( delta * coeff ) < 0.0 &&
+                rowPair.first.type() !== SymbolType.External ) {
+                this._infeasibleRows.push( rowPair.first );
+            }
+        }
+        this._dualOptimize();
+    }
+
+    /**
+     * Update the values of the variables.
+     */
+    public updateVariables(): void {
+        let vars = this._varMap;
+        let rows = this._rowMap;
+        for ( let i = 0, n = vars.size(); i < n; ++i ) {
+            let pair = vars.itemAt( i );
+            let rowPair = rows.find( pair.second );
+            if ( rowPair !== undefined ) {
+                pair.first.setValue( rowPair.second.constant() );
+            } else {
+                pair.first.setValue( 0.0 );
+            }
+        }
+    }
+
+    /**
+     * Get the symbol for the given variable.
+     *
+     * If a symbol does not exist for the variable, one will be created.
+     * @private
+     */
+    private _getVarSymbol( variable: Variable ): Symbol {
+        let factory = () => this._makeSymbol( SymbolType.External );
+        return this._varMap.setDefault( variable, factory ).second;
+    }
+
+    /**
+     * Create a new Row object for the given constraint.
+     *
+     * The terms in the constraint will be converted to cells in the row.
+     * Any term in the constraint with a coefficient of zero is ignored.
+     * This method uses the `_getVarSymbol` method to get the symbol for
+     * the variables added to the row. If the symbol for a given cell
+     * variable is basic, the cell variable will be substituted with the
+     * basic row.
+     *
+     * The necessary slack and error variables will be added to the row.
+     * If the constant for the row is negative, the sign for the row
+     * will be inverted so the constant becomes positive.
+     *
+     * Returns the created Row and the tag for tracking the constraint.
+     * @private
+     */
+    private _createRow( constraint: Constraint ): IRowCreation {
+        let expr = constraint.expression();
+        let row = new Row( expr.constant() );
+
+        // Substitute the current basic variables into the row.
+        let terms = expr.terms();
+        for ( let i = 0, n = terms.size(); i < n; ++i ) {
+            let termPair = terms.itemAt( i );
+            if ( !nearZero( termPair.second ) ) {
+                let symbol = this._getVarSymbol( termPair.first );
+                let basicPair = this._rowMap.find( symbol );
+                if ( basicPair !== undefined ) {
+                    row.insertRow( basicPair.second, termPair.second );
                 } else {
-                    pair.first.setValue( 0.0 );
+                    row.insertSymbol( symbol, termPair.second );
                 }
             }
         }
 
-        /**
-         * Get the symbol for the given variable.
-         *
-         * If a symbol does not exist for the variable, one will be created.
-         * @private
-         */
-        private _getVarSymbol( variable: Variable ): Symbol {
-            let factory = () => this._makeSymbol( SymbolType.External );
-            return this._varMap.setDefault( variable, factory ).second;
+        // Add the necessary slack, error, and dummy variables.
+        let objective = this._objective;
+        let strength = constraint.strength();
+        let tag = { marker: INVALID_SYMBOL, other: INVALID_SYMBOL };
+        switch ( constraint.op() ) {
+            case Operator.Le:
+            case Operator.Ge:
+            {
+                let coeff = constraint.op() === Operator.Le ? 1.0 : -1.0;
+                let slack = this._makeSymbol( SymbolType.Slack );
+                tag.marker = slack;
+                row.insertSymbol( slack, coeff );
+                if ( strength < Strength.required ) {
+                    let error = this._makeSymbol( SymbolType.Error );
+                    tag.other = error;
+                    row.insertSymbol( error, -coeff );
+                    objective.insertSymbol( error, strength );
+                }
+                break;
+            }
+            case Operator.Eq:
+            {
+                if ( strength < Strength.required ) {
+                    let errplus = this._makeSymbol( SymbolType.Error );
+                    let errminus = this._makeSymbol( SymbolType.Error );
+                    tag.marker = errplus;
+                    tag.other = errminus;
+                    row.insertSymbol( errplus, -1.0 ); // v = eplus - eminus
+                    row.insertSymbol( errminus, 1.0 ); // v - eplus + eminus = 0
+                    objective.insertSymbol( errplus, strength );
+                    objective.insertSymbol( errminus, strength );
+                } else {
+                    let dummy = this._makeSymbol( SymbolType.Dummy );
+                    tag.marker = dummy;
+                    row.insertSymbol( dummy );
+                }
+                break;
+            }
         }
 
-        /**
-         * Create a new Row object for the given constraint.
-         *
-         * The terms in the constraint will be converted to cells in the row.
-         * Any term in the constraint with a coefficient of zero is ignored.
-         * This method uses the `_getVarSymbol` method to get the symbol for
-         * the variables added to the row. If the symbol for a given cell
-         * variable is basic, the cell variable will be substituted with the
-         * basic row.
-         *
-         * The necessary slack and error variables will be added to the row.
-         * If the constant for the row is negative, the sign for the row
-         * will be inverted so the constant becomes positive.
-         *
-         * Returns the created Row and the tag for tracking the constraint.
-         * @private
-         */
-        private _createRow( constraint: Constraint ): IRowCreation {
-            let expr = constraint.expression();
-            let row = new Row( expr.constant() );
-
-            // Substitute the current basic variables into the row.
-            let terms = expr.terms();
-            for ( let i = 0, n = terms.size(); i < n; ++i ) {
-                let termPair = terms.itemAt( i );
-                if ( !nearZero( termPair.second ) ) {
-                    let symbol = this._getVarSymbol( termPair.first );
-                    let basicPair = this._rowMap.find( symbol );
-                    if ( basicPair !== undefined ) {
-                        row.insertRow( basicPair.second, termPair.second );
-                    } else {
-                        row.insertSymbol( symbol, termPair.second );
-                    }
-                }
-            }
-
-            // Add the necessary slack, error, and dummy variables.
-            let objective = this._objective;
-            let strength = constraint.strength();
-            let tag = { marker: INVALID_SYMBOL, other: INVALID_SYMBOL };
-            switch ( constraint.op() ) {
-                case Operator.Le:
-                case Operator.Ge:
-                {
-                    let coeff = constraint.op() === Operator.Le ? 1.0 : -1.0;
-                    let slack = this._makeSymbol( SymbolType.Slack );
-                    tag.marker = slack;
-                    row.insertSymbol( slack, coeff );
-                    if ( strength < Strength.required ) {
-                        let error = this._makeSymbol( SymbolType.Error );
-                        tag.other = error;
-                        row.insertSymbol( error, -coeff );
-                        objective.insertSymbol( error, strength );
-                    }
-                    break;
-                }
-                case Operator.Eq:
-                {
-                    if ( strength < Strength.required ) {
-                        let errplus = this._makeSymbol( SymbolType.Error );
-                        let errminus = this._makeSymbol( SymbolType.Error );
-                        tag.marker = errplus;
-                        tag.other = errminus;
-                        row.insertSymbol( errplus, -1.0 ); // v = eplus - eminus
-                        row.insertSymbol( errminus, 1.0 ); // v - eplus + eminus = 0
-                        objective.insertSymbol( errplus, strength );
-                        objective.insertSymbol( errminus, strength );
-                    } else {
-                        let dummy = this._makeSymbol( SymbolType.Dummy );
-                        tag.marker = dummy;
-                        row.insertSymbol( dummy );
-                    }
-                    break;
-                }
-            }
-
-            // Ensure the row has a positive constant.
-            if ( row.constant() < 0.0 ) {
-                row.reverseSign();
-            }
-
-            return { row, tag };
+        // Ensure the row has a positive constant.
+        if ( row.constant() < 0.0 ) {
+            row.reverseSign();
         }
 
-        /**
-         * Choose the subject for solving for the row.
-         *
-         * This method will choose the best subject for using as the solve
-         * target for the row. An invalid symbol will be returned if there
-         * is no valid target.
-         *
-         * The symbols are chosen according to the following precedence:
-         *
-         * 1) The first symbol representing an external variable.
-         * 2) A negative slack or error tag variable.
-         *
-         * If a subject cannot be found, an invalid symbol will be returned.
-         *
-         * @private
-         */
-        private _chooseSubject( row: Row, tag: ITag ): Symbol {
-            let cells = row.cells();
-            for ( let i = 0, n = cells.size(); i < n; ++i ) {
-                let pair = cells.itemAt( i );
-                if ( pair.first.type() === SymbolType.External ) {
-                    return pair.first;
-                }
+        return { row, tag };
+    }
+
+    /**
+     * Choose the subject for solving for the row.
+     *
+     * This method will choose the best subject for using as the solve
+     * target for the row. An invalid symbol will be returned if there
+     * is no valid target.
+     *
+     * The symbols are chosen according to the following precedence:
+     *
+     * 1) The first symbol representing an external variable.
+     * 2) A negative slack or error tag variable.
+     *
+     * If a subject cannot be found, an invalid symbol will be returned.
+     *
+     * @private
+     */
+    private _chooseSubject( row: Row, tag: ITag ): Symbol {
+        let cells = row.cells();
+        for ( let i = 0, n = cells.size(); i < n; ++i ) {
+            let pair = cells.itemAt( i );
+            if ( pair.first.type() === SymbolType.External ) {
+                return pair.first;
             }
-            let type = tag.marker.type();
-            if ( type === SymbolType.Slack || type === SymbolType.Error ) {
-                if ( row.coefficientFor( tag.marker ) < 0.0 ) {
-                    return tag.marker;
-                }
+        }
+        let type = tag.marker.type();
+        if ( type === SymbolType.Slack || type === SymbolType.Error ) {
+            if ( row.coefficientFor( tag.marker ) < 0.0 ) {
+                return tag.marker;
             }
-            type = tag.other.type();
-            if ( type === SymbolType.Slack || type === SymbolType.Error ) {
-                if ( row.coefficientFor( tag.other ) < 0.0 ) {
-                    return tag.other;
-                }
+        }
+        type = tag.other.type();
+        if ( type === SymbolType.Slack || type === SymbolType.Error ) {
+            if ( row.coefficientFor( tag.other ) < 0.0 ) {
+                return tag.other;
             }
-            return INVALID_SYMBOL;
+        }
+        return INVALID_SYMBOL;
+    }
+
+    /**
+     * Add the row to the tableau using an artificial variable.
+     *
+     * This will return false if the constraint cannot be satisfied.
+     *
+     * @private
+     */
+    private _addWithArtificialVariable( row: Row ): boolean {
+        // Create and add the artificial variable to the tableau.
+        let art = this._makeSymbol( SymbolType.Slack );
+        this._rowMap.insert( art, row.copy() );
+        this._artificial = row.copy();
+
+        // Optimize the artificial objective. This is successful
+        // only if the artificial objective is optimized to zero.
+        this._optimize( this._artificial );
+        let success = nearZero( this._artificial.constant() );
+        this._artificial = null;
+
+        // If the artificial variable is basic, pivot the row so that
+        // it becomes non-basic. If the row is constant, exit early.
+        let pair = this._rowMap.erase( art );
+        if ( pair !== undefined ) {
+            let basicRow = pair.second;
+            if ( basicRow.isConstant() ) {
+                return success;
+            }
+            let entering = this._anyPivotableSymbol( basicRow );
+            if ( entering.type() === SymbolType.Invalid ) {
+                return false;  // unsatisfiable (will this ever happen?)
+            }
+            basicRow.solveForEx( art, entering );
+            this._substitute( entering, basicRow );
+            this._rowMap.insert( entering, basicRow );
         }
 
-        /**
-         * Add the row to the tableau using an artificial variable.
-         *
-         * This will return false if the constraint cannot be satisfied.
-         *
-         * @private
-         */
-        private _addWithArtificialVariable( row: Row ): boolean {
-            // Create and add the artificial variable to the tableau.
-            let art = this._makeSymbol( SymbolType.Slack );
-            this._rowMap.insert( art, row.copy() );
-            this._artificial = row.copy();
+        // Remove the artificial variable from the tableau.
+        let rows = this._rowMap;
+        for ( let i = 0, n = rows.size(); i < n; ++i ) {
+            rows.itemAt( i ).second.removeSymbol( art );
+        }
+        this._objective.removeSymbol( art );
+        return success;
+    }
 
-            // Optimize the artificial objective. This is successful
-            // only if the artificial objective is optimized to zero.
-            this._optimize( this._artificial );
-            let success = nearZero( this._artificial.constant() );
-            this._artificial = null;
+    /**
+     * Substitute the parametric symbol with the given row.
+     *
+     * This method will substitute all instances of the parametric symbol
+     * in the tableau and the objective function with the given row.
+     *
+     * @private
+     */
+    private _substitute( symbol: Symbol, row: Row ): void {
+        let rows = this._rowMap;
+        for ( let i = 0, n = rows.size(); i < n; ++i ) {
+            let pair = rows.itemAt( i );
+            pair.second.substitute( symbol, row );
+            if ( pair.second.constant() < 0.0 &&
+                pair.first.type() !== SymbolType.External ) {
+                this._infeasibleRows.push( pair.first );
+            }
+        }
+        this._objective.substitute( symbol, row );
+        if ( this._artificial ) {
+            this._artificial.substitute( symbol, row );
+        }
+    }
 
-            // If the artificial variable is basic, pivot the row so that
-            // it becomes non-basic. If the row is constant, exit early.
-            let pair = this._rowMap.erase( art );
-            if ( pair !== undefined ) {
-                let basicRow = pair.second;
-                if ( basicRow.isConstant() ) {
-                    return success;
-                }
-                let entering = this._anyPivotableSymbol( basicRow );
+    /**
+     * Optimize the system for the given objective function.
+     *
+     * This method performs iterations of Phase 2 of the simplex method
+     * until the objective function reaches a minimum.
+     *
+     * @private
+     */
+    private _optimize( objective: Row ): void {
+        while ( true ) {
+            let entering = this._getEnteringSymbol( objective );
+            if ( entering.type() === SymbolType.Invalid ) {
+                return;
+            }
+            let leaving = this._getLeavingSymbol( entering );
+            if ( leaving.type() === SymbolType.Invalid ) {
+                throw new Error( "the objective is unbounded" );
+            }
+            // pivot the entering symbol into the basis
+            let row = this._rowMap.erase( leaving ).second;
+            row.solveForEx( leaving, entering );
+            this._substitute( entering, row );
+            this._rowMap.insert( entering, row );
+        }
+    }
+
+    /**
+     * Optimize the system using the dual of the simplex method.
+     *
+     * The current state of the system should be such that the objective
+     * function is optimal, but not feasible. This method will perform
+     * an iteration of the dual simplex method to make the solution both
+     * optimal and feasible.
+     *
+     * @private
+     */
+    private _dualOptimize(): void {
+        let rows = this._rowMap;
+        let infeasible = this._infeasibleRows;
+        while ( infeasible.length !== 0 ) {
+            let leaving = infeasible.pop();
+            let pair = rows.find( leaving );
+            if ( pair !== undefined && pair.second.constant() < 0.0 ) {
+                let entering = this._getDualEnteringSymbol( pair.second );
                 if ( entering.type() === SymbolType.Invalid ) {
-                    return false;  // unsatisfiable (will this ever happen?)
-                }
-                basicRow.solveForEx( art, entering );
-                this._substitute( entering, basicRow );
-                this._rowMap.insert( entering, basicRow );
-            }
-
-            // Remove the artificial variable from the tableau.
-            let rows = this._rowMap;
-            for ( let i = 0, n = rows.size(); i < n; ++i ) {
-                rows.itemAt( i ).second.removeSymbol( art );
-            }
-            this._objective.removeSymbol( art );
-            return success;
-        }
-
-        /**
-         * Substitute the parametric symbol with the given row.
-         *
-         * This method will substitute all instances of the parametric symbol
-         * in the tableau and the objective function with the given row.
-         *
-         * @private
-         */
-        private _substitute( symbol: Symbol, row: Row ): void {
-            let rows = this._rowMap;
-            for ( let i = 0, n = rows.size(); i < n; ++i ) {
-                let pair = rows.itemAt( i );
-                pair.second.substitute( symbol, row );
-                if ( pair.second.constant() < 0.0 &&
-                    pair.first.type() !== SymbolType.External ) {
-                    this._infeasibleRows.push( pair.first );
-                }
-            }
-            this._objective.substitute( symbol, row );
-            if ( this._artificial ) {
-                this._artificial.substitute( symbol, row );
-            }
-        }
-
-        /**
-         * Optimize the system for the given objective function.
-         *
-         * This method performs iterations of Phase 2 of the simplex method
-         * until the objective function reaches a minimum.
-         *
-         * @private
-         */
-        private _optimize( objective: Row ): void {
-            while ( true ) {
-                let entering = this._getEnteringSymbol( objective );
-                if ( entering.type() === SymbolType.Invalid ) {
-                    return;
-                }
-                let leaving = this._getLeavingSymbol( entering );
-                if ( leaving.type() === SymbolType.Invalid ) {
-                    throw new Error( "the objective is unbounded" );
+                    throw new Error( "dual optimize failed" );
                 }
                 // pivot the entering symbol into the basis
-                let row = this._rowMap.erase( leaving ).second;
+                let row = pair.second;
+                rows.erase( leaving );
                 row.solveForEx( leaving, entering );
                 this._substitute( entering, row );
-                this._rowMap.insert( entering, row );
+                rows.insert( entering, row );
             }
         }
+    }
 
-        /**
-         * Optimize the system using the dual of the simplex method.
-         *
-         * The current state of the system should be such that the objective
-         * function is optimal, but not feasible. This method will perform
-         * an iteration of the dual simplex method to make the solution both
-         * optimal and feasible.
-         *
-         * @private
-         */
-        private _dualOptimize(): void {
-            let rows = this._rowMap;
-            let infeasible = this._infeasibleRows;
-            while ( infeasible.length !== 0 ) {
-                let leaving = infeasible.pop();
-                let pair = rows.find( leaving );
-                if ( pair !== undefined && pair.second.constant() < 0.0 ) {
-                    let entering = this._getDualEnteringSymbol( pair.second );
-                    if ( entering.type() === SymbolType.Invalid ) {
-                        throw new Error( "dual optimize failed" );
-                    }
-                    // pivot the entering symbol into the basis
-                    let row = pair.second;
-                    rows.erase( leaving );
-                    row.solveForEx( leaving, entering );
-                    this._substitute( entering, row );
-                    rows.insert( entering, row );
+    /**
+     * Compute the entering variable for a pivot operation.
+     *
+     * This method will return first symbol in the objective function which
+     * is non-dummy and has a coefficient less than zero. If no symbol meets
+     * the criteria, it means the objective function is at a minimum, and an
+     * invalid symbol is returned.
+     *
+     * @private
+     */
+    private _getEnteringSymbol( objective: Row ): Symbol {
+        let cells = objective.cells();
+        for ( let i = 0, n = cells.size(); i < n; ++i ) {
+            let pair = cells.itemAt( i );
+            let symbol = pair.first;
+            if ( pair.second < 0.0 && symbol.type() !== SymbolType.Dummy ) {
+                return symbol;
+            }
+        }
+        return INVALID_SYMBOL;
+    }
+
+    /**
+     * Compute the entering symbol for the dual optimize operation.
+     *
+     * This method will return the symbol in the row which has a positive
+     * coefficient and yields the minimum ratio for its respective symbol
+     * in the objective function. The provided row *must* be infeasible.
+     * If no symbol is found which meats the criteria, an invalid symbol
+     * is returned.
+     *
+     * @private
+     */
+    private _getDualEnteringSymbol( row: Row ): Symbol {
+        let ratio = Number.MAX_VALUE;
+        let entering = INVALID_SYMBOL;
+        let cells = row.cells();
+        for ( let i = 0, n = cells.size(); i < n; ++i ) {
+            let pair = cells.itemAt( i );
+            let symbol = pair.first;
+            let c = pair.second;
+            if ( c > 0.0 && symbol.type() !== SymbolType.Dummy ) {
+                let coeff = this._objective.coefficientFor( symbol );
+                let r = coeff / c;
+                if ( r < ratio ) {
+                    ratio = r;
+                    entering = symbol;
                 }
             }
         }
+        return entering;
+    }
 
-        /**
-         * Compute the entering variable for a pivot operation.
-         *
-         * This method will return first symbol in the objective function which
-         * is non-dummy and has a coefficient less than zero. If no symbol meets
-         * the criteria, it means the objective function is at a minimum, and an
-         * invalid symbol is returned.
-         *
-         * @private
-         */
-        private _getEnteringSymbol( objective: Row ): Symbol {
-            let cells = objective.cells();
-            for ( let i = 0, n = cells.size(); i < n; ++i ) {
-                let pair = cells.itemAt( i );
-                let symbol = pair.first;
-                if ( pair.second < 0.0 && symbol.type() !== SymbolType.Dummy ) {
-                    return symbol;
-                }
-            }
-            return INVALID_SYMBOL;
-        }
-
-        /**
-         * Compute the entering symbol for the dual optimize operation.
-         *
-         * This method will return the symbol in the row which has a positive
-         * coefficient and yields the minimum ratio for its respective symbol
-         * in the objective function. The provided row *must* be infeasible.
-         * If no symbol is found which meats the criteria, an invalid symbol
-         * is returned.
-         *
-         * @private
-         */
-        private _getDualEnteringSymbol( row: Row ): Symbol {
-            let ratio = Number.MAX_VALUE;
-            let entering = INVALID_SYMBOL;
-            let cells = row.cells();
-            for ( let i = 0, n = cells.size(); i < n; ++i ) {
-                let pair = cells.itemAt( i );
-                let symbol = pair.first;
-                let c = pair.second;
-                if ( c > 0.0 && symbol.type() !== SymbolType.Dummy ) {
-                    let coeff = this._objective.coefficientFor( symbol );
-                    let r = coeff / c;
-                    if ( r < ratio ) {
-                        ratio = r;
-                        entering = symbol;
-                    }
-                }
-            }
-            return entering;
-        }
-
-        /**
-         * Compute the symbol for pivot exit row.
-         *
-         * This method will return the symbol for the exit row in the row
-         * map. If no appropriate exit symbol is found, an invalid symbol
-         * will be returned. This indicates that the objective function is
-         * unbounded.
-         *
-         * @private
-         */
-        private _getLeavingSymbol( entering: Symbol ): Symbol {
-            let ratio = Number.MAX_VALUE;
-            let found = INVALID_SYMBOL;
-            let rows = this._rowMap;
-            for ( let i = 0, n = rows.size(); i < n; ++i ) {
-                let pair = rows.itemAt( i );
-                let symbol = pair.first;
-                if ( symbol.type() !== SymbolType.External ) {
-                    let row = pair.second;
-                    let temp = row.coefficientFor( entering );
-                    if ( temp < 0.0 ) {
-                        let temp_ratio = -row.constant() / temp;
-                        if ( temp_ratio < ratio ) {
-                            ratio = temp_ratio;
-                            found = symbol;
-                        }
-                    }
-                }
-            }
-            return found;
-        }
-
-        /**
-         * Compute the leaving symbol for a marker variable.
-         *
-         * This method will return a symbol corresponding to a basic row
-         * which holds the given marker variable. The row will be chosen
-         * according to the following precedence:
-         *
-         * 1) The row with a restricted basic varible and a negative coefficient
-         *    for the marker with the smallest ratio of -constant / coefficient.
-         *
-         * 2) The row with a restricted basic variable and the smallest ratio
-         *    of constant / coefficient.
-         *
-         * 3) The last unrestricted row which contains the marker.
-         *
-         * If the marker does not exist in any row, an invalid symbol will be
-         * returned. This indicates an internal solver error since the marker
-         * *should* exist somewhere in the tableau.
-         *
-         * @private
-         */
-        private _getMarkerLeavingSymbol( marker: Symbol ): Symbol {
-            let dmax = Number.MAX_VALUE;
-            let r1 = dmax;
-            let r2 = dmax;
-            let invalid = INVALID_SYMBOL;
-            let first = invalid;
-            let second = invalid;
-            let third = invalid;
-            let rows = this._rowMap;
-            for ( let i = 0, n = rows.size(); i < n; ++i ) {
-                let pair = rows.itemAt( i );
+    /**
+     * Compute the symbol for pivot exit row.
+     *
+     * This method will return the symbol for the exit row in the row
+     * map. If no appropriate exit symbol is found, an invalid symbol
+     * will be returned. This indicates that the objective function is
+     * unbounded.
+     *
+     * @private
+     */
+    private _getLeavingSymbol( entering: Symbol ): Symbol {
+        let ratio = Number.MAX_VALUE;
+        let found = INVALID_SYMBOL;
+        let rows = this._rowMap;
+        for ( let i = 0, n = rows.size(); i < n; ++i ) {
+            let pair = rows.itemAt( i );
+            let symbol = pair.first;
+            if ( symbol.type() !== SymbolType.External ) {
                 let row = pair.second;
-                let c = row.coefficientFor( marker );
-                if ( c === 0.0 ) {
-                    continue;
-                }
-                let symbol = pair.first;
-                if ( symbol.type() === SymbolType.External ) {
-                    third = symbol;
-                } else if ( c < 0.0 ) {
-                    let r = -row.constant() / c;
-                    if ( r < r1 ) {
-                        r1 = r;
-                        first = symbol;
-                    }
-                } else {
-                    let r = row.constant() / c;
-                    if ( r < r2 ) {
-                        r2 = r;
-                        second = symbol;
+                let temp = row.coefficientFor( entering );
+                if ( temp < 0.0 ) {
+                    let temp_ratio = -row.constant() / temp;
+                    if ( temp_ratio < ratio ) {
+                        ratio = temp_ratio;
+                        found = symbol;
                     }
                 }
             }
-            if ( first !== invalid ) {
-                return first;
-            }
-            if ( second !== invalid ) {
-                return second;
-            }
-            return third;
         }
+        return found;
+    }
 
-        /**
-         * Remove the effects of a constraint on the objective function.
-         *
-         * @private
-         */
-        private _removeConstraintEffects( cn: Constraint, tag: ITag ): void {
-            if ( tag.marker.type() === SymbolType.Error ) {
-                this._removeMarkerEffects( tag.marker, cn.strength() );
+    /**
+     * Compute the leaving symbol for a marker variable.
+     *
+     * This method will return a symbol corresponding to a basic row
+     * which holds the given marker variable. The row will be chosen
+     * according to the following precedence:
+     *
+     * 1) The row with a restricted basic varible and a negative coefficient
+     *    for the marker with the smallest ratio of -constant / coefficient.
+     *
+     * 2) The row with a restricted basic variable and the smallest ratio
+     *    of constant / coefficient.
+     *
+     * 3) The last unrestricted row which contains the marker.
+     *
+     * If the marker does not exist in any row, an invalid symbol will be
+     * returned. This indicates an internal solver error since the marker
+     * *should* exist somewhere in the tableau.
+     *
+     * @private
+     */
+    private _getMarkerLeavingSymbol( marker: Symbol ): Symbol {
+        let dmax = Number.MAX_VALUE;
+        let r1 = dmax;
+        let r2 = dmax;
+        let invalid = INVALID_SYMBOL;
+        let first = invalid;
+        let second = invalid;
+        let third = invalid;
+        let rows = this._rowMap;
+        for ( let i = 0, n = rows.size(); i < n; ++i ) {
+            let pair = rows.itemAt( i );
+            let row = pair.second;
+            let c = row.coefficientFor( marker );
+            if ( c === 0.0 ) {
+                continue;
             }
-            if ( tag.other.type() === SymbolType.Error ) {
-                this._removeMarkerEffects( tag.other, cn.strength() );
-            }
-        }
-
-        /**
-         * Remove the effects of an error marker on the objective function.
-         *
-         * @private
-         */
-        private _removeMarkerEffects( marker: Symbol, strength: number ): void {
-            let pair = this._rowMap.find( marker );
-            if ( pair !== undefined ) {
-                this._objective.insertRow( pair.second, -strength );
+            let symbol = pair.first;
+            if ( symbol.type() === SymbolType.External ) {
+                third = symbol;
+            } else if ( c < 0.0 ) {
+                let r = -row.constant() / c;
+                if ( r < r1 ) {
+                    r1 = r;
+                    first = symbol;
+                }
             } else {
-                this._objective.insertSymbol( marker, -strength );
-            }
-        }
-
-        /**
-         * Get the first Slack or Error symbol in the row.
-         *
-         * If no such symbol is present, an invalid symbol will be returned.
-         *
-         * @private
-         */
-        private _anyPivotableSymbol( row: Row ): Symbol {
-            let cells = row.cells();
-            for ( let i = 0, n = cells.size(); i < n; ++i ) {
-                let pair = cells.itemAt( i );
-                let type = pair.first.type();
-                if ( type === SymbolType.Slack || type === SymbolType.Error ) {
-                    return pair.first;
+                let r = row.constant() / c;
+                if ( r < r2 ) {
+                    r2 = r;
+                    second = symbol;
                 }
             }
-            return INVALID_SYMBOL;
         }
-
-        /**
-         * Returns a new Symbol of the given type.
-         *
-         * @private
-         */
-        private _makeSymbol( type: SymbolType ): Symbol {
-            return new Symbol( type, this._idTick++ );
+        if ( first !== invalid ) {
+            return first;
         }
-
-        private _cnMap = createCnMap();
-        private _rowMap = createRowMap();
-        private _varMap = createVarMap();
-        private _editMap = createEditMap();
-        private _infeasibleRows: Symbol[] = [];
-        private _objective: Row = new Row();
-        private _artificial: Row = null;
-        private _idTick: number = 0;
+        if ( second !== invalid ) {
+            return second;
+        }
+        return third;
     }
 
     /**
-     * Test whether a value is approximately zero.
+     * Remove the effects of a constraint on the objective function.
+     *
      * @private
      */
-    function nearZero( value: number ): boolean {
-        let eps = 1.0e-8;
-        return value < 0.0 ? -value < eps : value < eps;
+    private _removeConstraintEffects( cn: Constraint, tag: ITag ): void {
+        if ( tag.marker.type() === SymbolType.Error ) {
+            this._removeMarkerEffects( tag.marker, cn.strength() );
+        }
+        if ( tag.other.type() === SymbolType.Error ) {
+            this._removeMarkerEffects( tag.other, cn.strength() );
+        }
     }
 
     /**
-     * The internal interface of a tag value.
-     */
-    interface ITag {
-        marker: Symbol;
-        other: Symbol;
-    }
-
-    /**
-     * The internal interface of an edit info object.
-     */
-    interface IEditInfo {
-        tag: ITag;
-        constraint: Constraint;
-        constant: number;
-    }
-
-    /**
-     * The internal interface for returning created row data.
-     */
-    interface IRowCreation {
-        row: Row;
-        tag: ITag;
-    }
-
-    /**
-     * An internal function for creating a constraint map.
+     * Remove the effects of an error marker on the objective function.
+     *
      * @private
      */
-    function createCnMap(): IMap<Constraint, ITag> {
-        return createMap<Constraint, ITag>( Constraint.Compare );
+    private _removeMarkerEffects( marker: Symbol, strength: number ): void {
+        let pair = this._rowMap.find( marker );
+        if ( pair !== undefined ) {
+            this._objective.insertRow( pair.second, -strength );
+        } else {
+            this._objective.insertSymbol( marker, -strength );
+        }
     }
 
     /**
-     * An internal function for creating a row map.
+     * Get the first Slack or Error symbol in the row.
+     *
+     * If no such symbol is present, an invalid symbol will be returned.
+     *
      * @private
      */
-    function createRowMap(): IMap<Symbol, Row> {
-        return createMap<Symbol, Row>( Symbol.Compare );
-    }
-
-    /**
-     * An internal function for creating a variable map.
-     * @private
-     */
-    function createVarMap(): IMap<Variable, Symbol> {
-        return createMap<Variable, Symbol>( Variable.Compare );
-    }
-
-    /**
-     * An internal function for creating an edit map.
-     * @private
-     */
-    function createEditMap(): IMap<Variable, IEditInfo> {
-        return createMap<Variable, IEditInfo>( Variable.Compare );
-    }
-
-    /**
-     * An enum defining the available symbol types.
-     * @private
-     */
-    enum SymbolType {
-        Invalid,
-        External,
-        Slack,
-        Error,
-        Dummy,
-    }
-
-    /**
-     * An internal class representing a symbol in the solver.
-     * @private
-     */
-    class Symbol {
-        /**
-         * The static Symbol comparison function.
-         */
-        public static Compare( a: Symbol, b: Symbol ): number {
-            return a.id() - b.id();
-        }
-
-        /**
-         * Construct a new Symbol
-         *
-         * @param [type] The type of the symbol.
-         * @param [id] The unique id number of the symbol.
-         */
-        constructor( type: SymbolType, id: number ) {
-            this._id = id;
-            this._type = type;
-        }
-
-        /**
-         * Returns the unique id number of the symbol.
-         */
-        public id(): number {
-            return this._id;
-        }
-
-        /**
-         * Returns the type of the symbol.
-         */
-        public type(): SymbolType {
-            return this._type;
-        }
-
-        private _id: number;
-        private _type: SymbolType;
-    }
-
-    /**
-     * A static invalid symbol
-     * @private
-     */
-    let INVALID_SYMBOL = new Symbol( SymbolType.Invalid, -1 );
-
-    /**
-     * An internal row class used by the solver.
-     * @private
-     */
-    class Row {
-        /**
-         * Construct a new Row.
-         */
-        constructor( constant: number = 0.0 ) {
-            this._constant = constant;
-        }
-
-        /**
-         * Returns the mapping of symbols to coefficients.
-         */
-        public cells(): IMap<Symbol, number> {
-            return this._cellMap;
-        }
-
-        /**
-         * Returns the constant for the row.
-         */
-        public constant(): number {
-            return this._constant;
-        }
-
-        /**
-         * Returns true if the row is a constant value.
-         */
-        public isConstant(): boolean {
-            return this._cellMap.empty();
-        }
-
-        /**
-         * Returns true if the Row has all dummy symbols.
-         */
-        public allDummies(): boolean {
-            let cells = this._cellMap;
-            for ( let i = 0, n = cells.size(); i < n; ++i ) {
-                let pair = cells.itemAt( i );
-                if ( pair.first.type() !== SymbolType.Dummy ) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        /**
-         * Create a copy of the row.
-         */
-        public copy(): Row {
-            let theCopy = new Row( this._constant );
-            theCopy._cellMap = this._cellMap.copy();
-            return theCopy;
-        }
-
-        /**
-         * Add a constant value to the row constant.
-         *
-         * Returns the new value of the constant.
-         */
-        public add( value: number ): number {
-            return this._constant += value;
-        }
-
-        /**
-         * Insert the symbol into the row with the given coefficient.
-         *
-         * If the symbol already exists in the row, the coefficient
-         * will be added to the existing coefficient. If the resulting
-         * coefficient is zero, the symbol will be removed from the row.
-         */
-        public insertSymbol( symbol: Symbol, coefficient: number = 1.0 ): void {
-            let pair = this._cellMap.setDefault( symbol, () => 0.0 );
-            if ( nearZero( pair.second += coefficient ) ) {
-                this._cellMap.erase( symbol );
+    private _anyPivotableSymbol( row: Row ): Symbol {
+        let cells = row.cells();
+        for ( let i = 0, n = cells.size(); i < n; ++i ) {
+            let pair = cells.itemAt( i );
+            let type = pair.first.type();
+            if ( type === SymbolType.Slack || type === SymbolType.Error ) {
+                return pair.first;
             }
         }
+        return INVALID_SYMBOL;
+    }
 
-        /**
-         * Insert a row into this row with a given coefficient.
-         *
-         * The constant and the cells of the other row will be
-         * multiplied by the coefficient and added to this row. Any
-         * cell with a resulting coefficient of zero will be removed
-         * from the row.
-         */
-        public insertRow( other: Row, coefficient: number = 1.0 ): void {
-            this._constant += other._constant * coefficient;
-            let cells = other._cellMap;
-            for ( let i = 0, n = cells.size(); i < n; ++i ) {
-                let pair = cells.itemAt( i );
-                this.insertSymbol( pair.first, pair.second * coefficient );
+    /**
+     * Returns a new Symbol of the given type.
+     *
+     * @private
+     */
+    private _makeSymbol( type: SymbolType ): Symbol {
+        return new Symbol( type, this._idTick++ );
+    }
+
+    private _cnMap = createCnMap();
+    private _rowMap = createRowMap();
+    private _varMap = createVarMap();
+    private _editMap = createEditMap();
+    private _infeasibleRows: Symbol[] = [];
+    private _objective: Row = new Row();
+    private _artificial: Row = null;
+    private _idTick: number = 0;
+}
+
+/**
+ * Test whether a value is approximately zero.
+ * @private
+ */
+function nearZero( value: number ): boolean {
+    let eps = 1.0e-8;
+    return value < 0.0 ? -value < eps : value < eps;
+}
+
+/**
+ * The internal interface of a tag value.
+ */
+interface ITag {
+    marker: Symbol;
+    other: Symbol;
+}
+
+/**
+ * The internal interface of an edit info object.
+ */
+interface IEditInfo {
+    tag: ITag;
+    constraint: Constraint;
+    constant: number;
+}
+
+/**
+ * The internal interface for returning created row data.
+ */
+interface IRowCreation {
+    row: Row;
+    tag: ITag;
+}
+
+/**
+ * An internal function for creating a constraint map.
+ * @private
+ */
+function createCnMap(): IMap<Constraint, ITag> {
+    return createMap<Constraint, ITag>( Constraint.Compare );
+}
+
+/**
+ * An internal function for creating a row map.
+ * @private
+ */
+function createRowMap(): IMap<Symbol, Row> {
+    return createMap<Symbol, Row>( Symbol.Compare );
+}
+
+/**
+ * An internal function for creating a variable map.
+ * @private
+ */
+function createVarMap(): IMap<Variable, Symbol> {
+    return createMap<Variable, Symbol>( Variable.Compare );
+}
+
+/**
+ * An internal function for creating an edit map.
+ * @private
+ */
+function createEditMap(): IMap<Variable, IEditInfo> {
+    return createMap<Variable, IEditInfo>( Variable.Compare );
+}
+
+/**
+ * An enum defining the available symbol types.
+ * @private
+ */
+enum SymbolType {
+    Invalid,
+    External,
+    Slack,
+    Error,
+    Dummy,
+}
+
+/**
+ * An internal class representing a symbol in the solver.
+ * @private
+ */
+class Symbol {
+    /**
+     * The static Symbol comparison function.
+     */
+    public static Compare( a: Symbol, b: Symbol ): number {
+        return a.id() - b.id();
+    }
+
+    /**
+     * Construct a new Symbol
+     *
+     * @param [type] The type of the symbol.
+     * @param [id] The unique id number of the symbol.
+     */
+    constructor( type: SymbolType, id: number ) {
+        this._id = id;
+        this._type = type;
+    }
+
+    /**
+     * Returns the unique id number of the symbol.
+     */
+    public id(): number {
+        return this._id;
+    }
+
+    /**
+     * Returns the type of the symbol.
+     */
+    public type(): SymbolType {
+        return this._type;
+    }
+
+    private _id: number;
+    private _type: SymbolType;
+}
+
+/**
+ * A static invalid symbol
+ * @private
+ */
+let INVALID_SYMBOL = new Symbol( SymbolType.Invalid, -1 );
+
+/**
+ * An internal row class used by the solver.
+ * @private
+ */
+class Row {
+    /**
+     * Construct a new Row.
+     */
+    constructor( constant: number = 0.0 ) {
+        this._constant = constant;
+    }
+
+    /**
+     * Returns the mapping of symbols to coefficients.
+     */
+    public cells(): IMap<Symbol, number> {
+        return this._cellMap;
+    }
+
+    /**
+     * Returns the constant for the row.
+     */
+    public constant(): number {
+        return this._constant;
+    }
+
+    /**
+     * Returns true if the row is a constant value.
+     */
+    public isConstant(): boolean {
+        return this._cellMap.empty();
+    }
+
+    /**
+     * Returns true if the Row has all dummy symbols.
+     */
+    public allDummies(): boolean {
+        let cells = this._cellMap;
+        for ( let i = 0, n = cells.size(); i < n; ++i ) {
+            let pair = cells.itemAt( i );
+            if ( pair.first.type() !== SymbolType.Dummy ) {
+                return false;
             }
         }
+        return true;
+    }
 
-        /**
-         * Remove a symbol from the row.
-         */
-        public removeSymbol( symbol: Symbol ): void {
+    /**
+     * Create a copy of the row.
+     */
+    public copy(): Row {
+        let theCopy = new Row( this._constant );
+        theCopy._cellMap = this._cellMap.copy();
+        return theCopy;
+    }
+
+    /**
+     * Add a constant value to the row constant.
+     *
+     * Returns the new value of the constant.
+     */
+    public add( value: number ): number {
+        return this._constant += value;
+    }
+
+    /**
+     * Insert the symbol into the row with the given coefficient.
+     *
+     * If the symbol already exists in the row, the coefficient
+     * will be added to the existing coefficient. If the resulting
+     * coefficient is zero, the symbol will be removed from the row.
+     */
+    public insertSymbol( symbol: Symbol, coefficient: number = 1.0 ): void {
+        let pair = this._cellMap.setDefault( symbol, () => 0.0 );
+        if ( nearZero( pair.second += coefficient ) ) {
             this._cellMap.erase( symbol );
         }
-
-        /**
-         * Reverse the sign of the constant and cells in the row.
-         */
-        public reverseSign(): void {
-            this._constant = -this._constant;
-            let cells = this._cellMap;
-            for ( let i = 0, n = cells.size(); i < n; ++i ) {
-                let pair = cells.itemAt( i );
-                pair.second = -pair.second;
-            }
-        }
-
-        /**
-         * Solve the row for the given symbol.
-         *
-         * This method assumes the row is of the form
-         * a * x + b * y + c = 0 and (assuming solve for x) will modify
-         * the row to represent the right hand side of
-         * x = -b/a * y - c / a. The target symbol will be removed from
-         * the row, and the constant and other cells will be multiplied
-         * by the negative inverse of the target coefficient.
-         *
-         * The given symbol *must* exist in the row.
-         */
-        public solveFor( symbol: Symbol ): void {
-            let cells = this._cellMap;
-            let pair = cells.erase( symbol );
-            let coeff = -1.0 / pair.second;
-            this._constant *= coeff;
-            for ( let i = 0, n = cells.size(); i < n; ++i ) {
-                cells.itemAt( i ).second *= coeff;
-            }
-        }
-
-        /**
-         * Solve the row for the given symbols.
-         *
-         * This method assumes the row is of the form
-         * x = b * y + c and will solve the row such that
-         * y = x / b - c / b. The rhs symbol will be removed from the
-         * row, the lhs added, and the result divided by the negative
-         * inverse of the rhs coefficient.
-         *
-         * The lhs symbol *must not* exist in the row, and the rhs
-         * symbol must* exist in the row.
-         */
-        public solveForEx( lhs: Symbol, rhs: Symbol ): void {
-            this.insertSymbol( lhs, -1.0 );
-            this.solveFor( rhs );
-        }
-
-        /**
-         * Returns the coefficient for the given symbol.
-         */
-        public coefficientFor( symbol: Symbol ): number {
-            let pair = this._cellMap.find( symbol );
-            return pair !== undefined ? pair.second : 0.0;
-        }
-
-        /**
-         * Substitute a symbol with the data from another row.
-         *
-         * Given a row of the form a * x + b and a substitution of the
-         * form x = 3 * y + c the row will be updated to reflect the
-         * expression 3 * a * y + a * c + b.
-         *
-         * If the symbol does not exist in the row, this is a no-op.
-         */
-        public substitute( symbol: Symbol, row: Row ): void {
-            let pair = this._cellMap.erase( symbol );
-            if ( pair !== undefined ) {
-                this.insertRow( row, pair.second );
-            }
-        }
-
-        private _cellMap = createMap<Symbol, number>( Symbol.Compare );
-        private _constant: number;
     }
 
+    /**
+     * Insert a row into this row with a given coefficient.
+     *
+     * The constant and the cells of the other row will be
+     * multiplied by the coefficient and added to this row. Any
+     * cell with a resulting coefficient of zero will be removed
+     * from the row.
+     */
+    public insertRow( other: Row, coefficient: number = 1.0 ): void {
+        this._constant += other._constant * coefficient;
+        let cells = other._cellMap;
+        for ( let i = 0, n = cells.size(); i < n; ++i ) {
+            let pair = cells.itemAt( i );
+            this.insertSymbol( pair.first, pair.second * coefficient );
+        }
+    }
+
+    /**
+     * Remove a symbol from the row.
+     */
+    public removeSymbol( symbol: Symbol ): void {
+        this._cellMap.erase( symbol );
+    }
+
+    /**
+     * Reverse the sign of the constant and cells in the row.
+     */
+    public reverseSign(): void {
+        this._constant = -this._constant;
+        let cells = this._cellMap;
+        for ( let i = 0, n = cells.size(); i < n; ++i ) {
+            let pair = cells.itemAt( i );
+            pair.second = -pair.second;
+        }
+    }
+
+    /**
+     * Solve the row for the given symbol.
+     *
+     * This method assumes the row is of the form
+     * a * x + b * y + c = 0 and (assuming solve for x) will modify
+     * the row to represent the right hand side of
+     * x = -b/a * y - c / a. The target symbol will be removed from
+     * the row, and the constant and other cells will be multiplied
+     * by the negative inverse of the target coefficient.
+     *
+     * The given symbol *must* exist in the row.
+     */
+    public solveFor( symbol: Symbol ): void {
+        let cells = this._cellMap;
+        let pair = cells.erase( symbol );
+        let coeff = -1.0 / pair.second;
+        this._constant *= coeff;
+        for ( let i = 0, n = cells.size(); i < n; ++i ) {
+            cells.itemAt( i ).second *= coeff;
+        }
+    }
+
+    /**
+     * Solve the row for the given symbols.
+     *
+     * This method assumes the row is of the form
+     * x = b * y + c and will solve the row such that
+     * y = x / b - c / b. The rhs symbol will be removed from the
+     * row, the lhs added, and the result divided by the negative
+     * inverse of the rhs coefficient.
+     *
+     * The lhs symbol *must not* exist in the row, and the rhs
+     * symbol must* exist in the row.
+     */
+    public solveForEx( lhs: Symbol, rhs: Symbol ): void {
+        this.insertSymbol( lhs, -1.0 );
+        this.solveFor( rhs );
+    }
+
+    /**
+     * Returns the coefficient for the given symbol.
+     */
+    public coefficientFor( symbol: Symbol ): number {
+        let pair = this._cellMap.find( symbol );
+        return pair !== undefined ? pair.second : 0.0;
+    }
+
+    /**
+     * Substitute a symbol with the data from another row.
+     *
+     * Given a row of the form a * x + b and a substitution of the
+     * form x = 3 * y + c the row will be updated to reflect the
+     * expression 3 * a * y + a * c + b.
+     *
+     * If the symbol does not exist in the row, this is a no-op.
+     */
+    public substitute( symbol: Symbol, row: Row ): void {
+        let pair = this._cellMap.erase( symbol );
+        if ( pair !== undefined ) {
+            this.insertRow( row, pair.second );
+        }
+    }
+
+    private _cellMap = createMap<Symbol, number>( Symbol.Compare );
+    private _constant: number;
 }

--- a/src/strength.ts
+++ b/src/strength.ts
@@ -9,54 +9,49 @@
 /**
  * @class Strength
  */
+ export class Strength {
+    /**
+     * Create a new symbolic strength.
+     *
+     * @param {Number} a strong
+     * @param {Number} b medium
+     * @param {Number} c weak
+     * @param {Number} [w] weight
+     * @return {Number} strength
+    */
+    static create( a: number, b: number, c: number, w: number = 1.0 ) {
+        let result: number = 0.0;
+        result += Math.max( 0.0, Math.min( 1000.0, a * w ) ) * 1000000.0;
+        result += Math.max( 0.0, Math.min( 1000.0, b * w ) ) * 1000.0;
+        result += Math.max( 0.0, Math.min( 1000.0, c * w ) );
+        return result;
+    }
 
-/**
- * Create a new symbolic strength.
- *
- * @param {Number} a strong
- * @param {Number} b medium
- * @param {Number} c weak
- * @param {Number} [w] weight
- * @return {Number} strength
- */
-export
-function create( a: number, b: number, c: number, w: number = 1.0 ) {
-    let result: number = 0.0;
-    result += Math.max( 0.0, Math.min( 1000.0, a * w ) ) * 1000000.0;
-    result += Math.max( 0.0, Math.min( 1000.0, b * w ) ) * 1000.0;
-    result += Math.max( 0.0, Math.min( 1000.0, c * w ) );
-    return result;
-}
+    /**
+     * The 'required' symbolic strength.
+     */
+    static required = Strength.create( 1000.0, 1000.0, 1000.0 );
 
-/**
- * The 'required' symbolic strength.
- */
-export
-let required = create( 1000.0, 1000.0, 1000.0 );
+    /**
+     * The 'strong' symbolic strength.
+     */
+    static strong = Strength.create( 1.0, 0.0, 0.0 );
 
-/**
- * The 'strong' symbolic strength.
- */
-export
-let strong = create( 1.0, 0.0, 0.0 );
+    /**
+     * The 'medium' symbolic strength.
+     */
+    static medium = Strength.create( 0.0, 1.0, 0.0 );
 
-/**
- * The 'medium' symbolic strength.
- */
-export
-let medium = create( 0.0, 1.0, 0.0 );
+    /**
+     * The 'weak' symbolic strength.
+     */
+    static weak = Strength.create( 0.0, 0.0, 1.0 );
 
-/**
- * The 'weak' symbolic strength.
- */
-export
-let weak = create( 0.0, 0.0, 1.0 );
-
-/**
- * Clip a symbolic strength to the allowed min and max.
- * @private
- */
-export
-function clip( value: number ) {
-    return Math.max( 0.0, Math.min( required, value ) );
+    /**
+     * Clip a symbolic strength to the allowed min and max.
+     * @private
+     */
+    static clip( value: number ) {
+        return Math.max( 0.0, Math.min( Strength.required, value ) );
+    }
 }

--- a/src/strength.ts
+++ b/src/strength.ts
@@ -5,65 +5,58 @@
 |
 | The full license is in the file COPYING.txt, distributed with this software.
 |----------------------------------------------------------------------------*/
-namespace kiwi {
 
-    /**
-     * @class Strength
-     */
-    export
-    namespace Strength {
+/**
+ * @class Strength
+ */
 
-        /**
-         * Create a new symbolic strength.
-         *
-         * @param {Number} a strong
-         * @param {Number} b medium
-         * @param {Number} c weak
-         * @param {Number} [w] weight
-         * @return {Number} strength
-         */
-        export
-        function create( a: number, b: number, c: number, w: number = 1.0 ) {
-            let result: number = 0.0;
-            result += Math.max( 0.0, Math.min( 1000.0, a * w ) ) * 1000000.0;
-            result += Math.max( 0.0, Math.min( 1000.0, b * w ) ) * 1000.0;
-            result += Math.max( 0.0, Math.min( 1000.0, c * w ) );
-            return result;
-        }
+/**
+ * Create a new symbolic strength.
+ *
+ * @param {Number} a strong
+ * @param {Number} b medium
+ * @param {Number} c weak
+ * @param {Number} [w] weight
+ * @return {Number} strength
+ */
+export
+function create( a: number, b: number, c: number, w: number = 1.0 ) {
+    let result: number = 0.0;
+    result += Math.max( 0.0, Math.min( 1000.0, a * w ) ) * 1000000.0;
+    result += Math.max( 0.0, Math.min( 1000.0, b * w ) ) * 1000.0;
+    result += Math.max( 0.0, Math.min( 1000.0, c * w ) );
+    return result;
+}
 
-        /**
-         * The 'required' symbolic strength.
-         */
-        export
-        let required = create( 1000.0, 1000.0, 1000.0 );
+/**
+ * The 'required' symbolic strength.
+ */
+export
+let required = create( 1000.0, 1000.0, 1000.0 );
 
-        /**
-         * The 'strong' symbolic strength.
-         */
-        export
-        let strong = create( 1.0, 0.0, 0.0 );
+/**
+ * The 'strong' symbolic strength.
+ */
+export
+let strong = create( 1.0, 0.0, 0.0 );
 
-        /**
-         * The 'medium' symbolic strength.
-         */
-        export
-        let medium = create( 0.0, 1.0, 0.0 );
+/**
+ * The 'medium' symbolic strength.
+ */
+export
+let medium = create( 0.0, 1.0, 0.0 );
 
-        /**
-         * The 'weak' symbolic strength.
-         */
-        export
-        let weak = create( 0.0, 0.0, 1.0 );
+/**
+ * The 'weak' symbolic strength.
+ */
+export
+let weak = create( 0.0, 0.0, 1.0 );
 
-        /**
-         * Clip a symbolic strength to the allowed min and max.
-         * @private
-         */
-        export
-        function clip( value: number ) {
-            return Math.max( 0.0, Math.min( required, value ) );
-        }
-
-    }
-
+/**
+ * Clip a symbolic strength to the allowed min and max.
+ * @private
+ */
+export
+function clip( value: number ) {
+    return Math.max( 0.0, Math.min( required, value ) );
 }

--- a/src/variable.ts
+++ b/src/variable.ts
@@ -5,154 +5,153 @@
 |
 | The full license is in the file COPYING.txt, distributed with this software.
 |----------------------------------------------------------------------------*/
-namespace kiwi {
 
-    /**
-     * The primary user constraint variable.
-     *
-     * @class
-     * @param {String} [name=""] The name to associated with the variable.
-     */
-    export
-    class Variable {
-        constructor(name: string = "") {
-            this._name = name;
-        }
+import { Expression } from "./expression";
 
-        /**
-         * A static variable comparison function.
-         * @private
-         */
-        public static Compare( a: Variable, b: Variable ): number {
-            return a.id() - b.id();
-        }
-
-        /**
-         * Returns the unique id number of the variable.
-         * @private
-         */
-        public id(): number {
-            return this._id;
-        }
-
-        /**
-         * Returns the name of the variable.
-         *
-         * @return {String} name of the variable
-         */
-        public name(): string {
-            return this._name;
-        }
-
-        /**
-         * Set the name of the variable.
-         *
-         * @param {String} name Name of the variable
-         */
-        public setName( name: string ): void {
-            this._name = name;
-        }
-
-        /**
-         * Returns the user context object of the variable.
-         * @private
-         */
-        public context(): any {
-            return this._context;
-        }
-
-        /**
-         * Set the user context object of the variable.
-         * @private
-         */
-        public setContext( context: any ): void {
-            this._context = context;
-        }
-
-        /**
-         * Returns the value of the variable.
-         *
-         * @return {Number} Calculated value
-         */
-        public value(): number {
-            return this._value;
-        }
-
-        /**
-         * Set the value of the variable.
-         * @private
-         */
-        public setValue( value: number ): void {
-            this._value = value;
-        }
-
-        /**
-         * Creates a new Expression by adding a number, variable or expression
-         * to the variable.
-         *
-         * @param {Number|Variable|Expression} value Value to add.
-         * @return {Expression} expression
-         */
-        public plus( value: number|Variable|Expression ): Expression {
-            return new Expression(this, value);
-        }
-
-        /**
-         * Creates a new Expression by substracting a number, variable or expression
-         * from the variable.
-         *
-         * @param {Number|Variable|Expression} value Value to substract.
-         * @return {Expression} expression
-         */
-        public minus( value: number|Variable|Expression ): Expression {
-            return new Expression(this, typeof value === "number" ? -value : [-1, value]);
-        }
-
-        /**
-         * Creates a new Expression by multiplying with a fixed number.
-         *
-         * @param {Number} coefficient Coefficient to multiply with.
-         * @return {Expression} expression
-         */
-        public multiply( coefficient: number ): Expression {
-            return new Expression([coefficient, this]);
-        }
-
-        /**
-         * Creates a new Expression by dividing with a fixed number.
-         *
-         * @param {Number} coefficient Coefficient to divide by.
-         * @return {Expression} expression
-         */
-        public divide( coefficient: number ): Expression {
-            return new Expression([1 / coefficient, this]);
-        }
-
-        /**
-         * Returns the JSON representation of the variable.
-         * @private
-         */
-        public toJSON(): any {
-            return {
-                name: this._name,
-                value: this._value,
-            };
-        }
-
-        public toString(): string {
-            return this._context + "[" + this._name + ":" + this._value + "]";
-        }
-
-        private _name: string;
-        private _value: number = 0.0;
-        private _context: any = null;
-        private _id: number = VarId++;
+/**
+ * The primary user constraint variable.
+ *
+ * @class
+ * @param {String} [name=""] The name to associated with the variable.
+ */
+export
+class Variable {
+    constructor(name: string = "") {
+        this._name = name;
     }
 
     /**
-     * The internal variable id counter.
+     * A static variable comparison function.
      * @private
      */
-    let VarId = 0;
+    public static Compare( a: Variable, b: Variable ): number {
+        return a.id() - b.id();
+    }
 
+    /**
+     * Returns the unique id number of the variable.
+     * @private
+     */
+    public id(): number {
+        return this._id;
+    }
+
+    /**
+     * Returns the name of the variable.
+     *
+     * @return {String} name of the variable
+     */
+    public name(): string {
+        return this._name;
+    }
+
+    /**
+     * Set the name of the variable.
+     *
+     * @param {String} name Name of the variable
+     */
+    public setName( name: string ): void {
+        this._name = name;
+    }
+
+    /**
+     * Returns the user context object of the variable.
+     * @private
+     */
+    public context(): any {
+        return this._context;
+    }
+
+    /**
+     * Set the user context object of the variable.
+     * @private
+     */
+    public setContext( context: any ): void {
+        this._context = context;
+    }
+
+    /**
+     * Returns the value of the variable.
+     *
+     * @return {Number} Calculated value
+     */
+    public value(): number {
+        return this._value;
+    }
+
+    /**
+     * Set the value of the variable.
+     * @private
+     */
+    public setValue( value: number ): void {
+        this._value = value;
+    }
+
+    /**
+     * Creates a new Expression by adding a number, variable or expression
+     * to the variable.
+     *
+     * @param {Number|Variable|Expression} value Value to add.
+     * @return {Expression} expression
+     */
+    public plus( value: number|Variable|Expression ): Expression {
+        return new Expression(this, value);
+    }
+
+    /**
+     * Creates a new Expression by substracting a number, variable or expression
+     * from the variable.
+     *
+     * @param {Number|Variable|Expression} value Value to substract.
+     * @return {Expression} expression
+     */
+    public minus( value: number|Variable|Expression ): Expression {
+        return new Expression(this, typeof value === "number" ? -value : [-1, value]);
+    }
+
+    /**
+     * Creates a new Expression by multiplying with a fixed number.
+     *
+     * @param {Number} coefficient Coefficient to multiply with.
+     * @return {Expression} expression
+     */
+    public multiply( coefficient: number ): Expression {
+        return new Expression([coefficient, this]);
+    }
+
+    /**
+     * Creates a new Expression by dividing with a fixed number.
+     *
+     * @param {Number} coefficient Coefficient to divide by.
+     * @return {Expression} expression
+     */
+    public divide( coefficient: number ): Expression {
+        return new Expression([1 / coefficient, this]);
+    }
+
+    /**
+     * Returns the JSON representation of the variable.
+     * @private
+     */
+    public toJSON(): any {
+        return {
+            name: this._name,
+            value: this._value,
+        };
+    }
+
+    public toString(): string {
+        return this._context + "[" + this._name + ":" + this._value + "]";
+    }
+
+    private _name: string;
+    private _value: number = 0.0;
+    private _context: any = null;
+    private _id: number = VarId++;
 }
+
+/**
+ * The internal variable id counter.
+ * @private
+ */
+let VarId = 0;

--- a/thirdparty/tsu.d.ts
+++ b/thirdparty/tsu.d.ts
@@ -286,3 +286,4 @@ declare module tsu {
 }
 declare module tsu {
 }
+export = tsu;

--- a/thirdparty/tsu.js
+++ b/thirdparty/tsu.js
@@ -544,9 +544,3 @@ var tsu;
 |
 | The full license is in the file COPYING.txt, distributed with this software.
 |----------------------------------------------------------------------------*/
-/// <reference path="algorithm.ts"/>
-/// <reference path="array_base.ts"/>
-/// <reference path="associative_array.ts"/>
-/// <reference path="iterator.ts"/>
-/// <reference path="unique_array.ts"/>
-/// <reference path="utility.ts"/>

--- a/thirdparty/tsu.js
+++ b/thirdparty/tsu.js
@@ -5,122 +5,228 @@
 |
 | The full license is in the file COPYING.txt, distributed with this software.
 |----------------------------------------------------------------------------*/
-var tsu;
-(function (tsu) {
+/**
+* An iterator for an array of items.
+*/
+var ArrayIterator = (function () {
+    /*
+    * Construct a new ArrayIterator.
+    *
+    * @param array The array of items to iterate.
+    * @param [index] The index at which to start iteration.
+    */
+    function ArrayIterator(array, index) {
+        if (typeof index === "undefined") { index = 0; }
+        this._array = array;
+        this._index = Math.max(0, Math.min(index, array.length));
+    }
+    /**
+    * Returns the next item from the iterator or undefined.
+    */
+    ArrayIterator.prototype.__next__ = function () {
+        return this._array[this._index++];
+    };
 
     /**
-    * An iterator for an array of items.
+    * Returns this same iterator.
     */
-    var ArrayIterator = (function () {
-        /*
-        * Construct a new ArrayIterator.
-        *
-        * @param array The array of items to iterate.
-        * @param [index] The index at which to start iteration.
-        */
-        function ArrayIterator(array, index) {
-            if (typeof index === "undefined") { index = 0; }
-            this._array = array;
-            this._index = Math.max(0, Math.min(index, array.length));
-        }
-        /**
-        * Returns the next item from the iterator or undefined.
-        */
-        ArrayIterator.prototype.__next__ = function () {
-            return this._array[this._index++];
-        };
+    ArrayIterator.prototype.__iter__ = function () {
+        return this;
+    };
+    return ArrayIterator;
+})();
+export { ArrayIterator };
 
-        /**
-        * Returns this same iterator.
-        */
-        ArrayIterator.prototype.__iter__ = function () {
-            return this;
-        };
-        return ArrayIterator;
-    })();
-    tsu.ArrayIterator = ArrayIterator;
+/**
+* A reverse iterator for an array of items.
+*/
+var ReverseArrayIterator = (function () {
+    /**
+    * Construct a new ReverseArrayIterator.
+    *
+    * @param array The array of items to iterate.
+    * @param [index] The index at which to start iteration.
+    */
+    function ReverseArrayIterator(array, index) {
+        if (typeof index === "undefined") { index = array.length; }
+        this._array = array;
+        this._index = Math.max(0, Math.min(index, array.length));
+    }
+    /**
+    * Returns the next item from the iterator or undefined.
+    */
+    ReverseArrayIterator.prototype.__next__ = function () {
+        return this._array[--this._index];
+    };
 
     /**
-    * A reverse iterator for an array of items.
+    * Returns this same iterator.
     */
-    var ReverseArrayIterator = (function () {
-        /**
-        * Construct a new ReverseArrayIterator.
-        *
-        * @param array The array of items to iterate.
-        * @param [index] The index at which to start iteration.
-        */
-        function ReverseArrayIterator(array, index) {
-            if (typeof index === "undefined") { index = array.length; }
-            this._array = array;
-            this._index = Math.max(0, Math.min(index, array.length));
-        }
-        /**
-        * Returns the next item from the iterator or undefined.
-        */
-        ReverseArrayIterator.prototype.__next__ = function () {
-            return this._array[--this._index];
-        };
+    ReverseArrayIterator.prototype.__iter__ = function () {
+        return this;
+    };
+    return ReverseArrayIterator;
+})();
+export { ReverseArrayIterator };
 
-        /**
-        * Returns this same iterator.
-        */
-        ReverseArrayIterator.prototype.__iter__ = function () {
-            return this;
-        };
-        return ReverseArrayIterator;
-    })();
-    tsu.ReverseArrayIterator = ReverseArrayIterator;
 
-    
 
-    function iter(object) {
-        if (object instanceof Array) {
-            return new ArrayIterator(object);
-        }
-        return object.__iter__();
+function iter(object) {
+    if (object instanceof Array) {
+        return new ArrayIterator(object);
     }
-    tsu.iter = iter;
+    return object.__iter__();
+}
+export { iter };
 
-    
 
-    function reversed(object) {
-        if (object instanceof Array) {
-            return new ReverseArrayIterator(object);
-        }
-        return object.__reversed__();
+
+function reversed(object) {
+    if (object instanceof Array) {
+        return new ReverseArrayIterator(object);
     }
-    tsu.reversed = reversed;
+    return object.__reversed__();
+}
+export { reversed };
 
-    /**
-    * Returns the next value from an iterator, or undefined.
-    */
-    function next(iterator) {
-        return iterator.__next__();
-    }
-    tsu.next = next;
+/**
+* Returns the next value from an iterator, or undefined.
+*/
+function next(iterator) {
+    return iterator.__next__();
+}
+export { next };
 
 
-    function forEach(object, callback) {
-        if (object instanceof Array) {
-            for (var i = 0, n = object.length; i < n; ++i) {
-                if (callback(object[i]) === false) {
-                    return;
-                }
+function forEach(object, callback) {
+    if (object instanceof Array) {
+        for (var i = 0, n = object.length; i < n; ++i) {
+            if (callback(object[i]) === false) {
+                return;
             }
+        }
+    } else {
+        var value;
+        var it = object.__iter__();
+        while ((value = it.__next__()) !== undefined) {
+            if (callback(value) === false) {
+                return;
+            }
+        }
+    }
+}
+export { forEach };
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014, Nucleic Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|
+| The full license is in the file COPYING.txt, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+/**
+* A class which defines a generic pair object.
+*/
+var Pair = (function () {
+    /**
+    * Construct a new Pair object.
+    *
+    * @param first The first item of the pair.
+    * @param second The second item of the pair.
+    */
+    function Pair(first, second) {
+        this.first = first;
+        this.second = second;
+    }
+    /**
+    * Create a copy of the pair.
+    */
+    Pair.prototype.copy = function () {
+        return new Pair(this.first, this.second);
+    };
+    return Pair;
+})();
+export { Pair };
+
+/*-----------------------------------------------------------------------------
+| Copyright (c) 2014, Nucleic Development Team.
+|
+| Distributed under the terms of the Modified BSD License.
+|
+| The full license is in the file COPYING.txt, distributed with this software.
+|----------------------------------------------------------------------------*/
+
+/**
+* Perform a lower bound search on a sorted array.
+*
+* @param array The array of sorted items to search.
+* @param value The value to located in the array.
+* @param compare The value comparison function.
+* @returns The index of the first element in the array which
+*          compares greater than or equal to the given value.
+*/
+function lowerBound(array, value, compare) {
+    var begin = 0;
+    var n = array.length;
+    var half;
+    var middle;
+    while (n > 0) {
+        half = n >> 1;
+        middle = begin + half;
+        if (compare(array[middle], value) < 0) {
+            begin = middle + 1;
+            n -= half + 1;
         } else {
-            var value;
-            var it = object.__iter__();
-            while ((value = it.__next__()) !== undefined) {
-                if (callback(value) === false) {
-                    return;
-                }
-            }
+            n = half;
         }
     }
-    tsu.forEach = forEach;
+    return begin;
+}
+export { lowerBound };
 
-})(tsu || (tsu = {}));
+/**
+* Perform a binary search on a sorted array.
+*
+* @param array The array of sorted items to search.
+* @param value The value to located in the array.
+* @param compare The value comparison function.
+* @returns The index of the found item, or -1.
+*/
+function binarySearch(array, value, compare) {
+    var index = lowerBound(array, value, compare);
+    if (index === array.length) {
+        return -1;
+    }
+    var item = array[index];
+    if (compare(item, value) !== 0) {
+        return -1;
+    }
+    return index;
+}
+export { binarySearch };
+
+/**
+* Perform a binary find on a sorted array.
+*
+* @param array The array of sorted items to search.
+* @param value The value to located in the array.
+* @param compare The value comparison function.
+* @returns The found item in the array, or undefined.
+*/
+function binaryFind(array, value, compare) {
+    var index = lowerBound(array, value, compare);
+    if (index === array.length) {
+        return undefined;
+    }
+    var item = array[index];
+    if (compare(item, value) !== 0) {
+        return undefined;
+    }
+    return item;
+}
+export { binaryFind };
+
 /*-----------------------------------------------------------------------------
 | Copyright (c) 2014, Nucleic Development Team.
 |
@@ -128,34 +234,88 @@ var tsu;
 |
 | The full license is in the file COPYING.txt, distributed with this software.
 |----------------------------------------------------------------------------*/
-var tsu;
-(function (tsu) {
-    
+
+/**
+* A base class for implementing array-based data structures.
+*
+* @class
+*/
+var ArrayBase = (function () {
+    function ArrayBase() {
+        /*
+        * The internal data array.
+        *
+        * @protected
+        */
+        this._array = [];
+    }
+    /**
+    * Returns the number of items in the array.
+    */
+    ArrayBase.prototype.size = function () {
+        return this._array.length;
+    };
 
     /**
-    * A class which defines a generic pair object.
+    * Returns true if the array is empty.
     */
-    var Pair = (function () {
-        /**
-        * Construct a new Pair object.
-        *
-        * @param first The first item of the pair.
-        * @param second The second item of the pair.
-        */
-        function Pair(first, second) {
-            this.first = first;
-            this.second = second;
-        }
-        /**
-        * Create a copy of the pair.
-        */
-        Pair.prototype.copy = function () {
-            return new Pair(this.first, this.second);
-        };
-        return Pair;
-    })();
-    tsu.Pair = Pair;
-})(tsu || (tsu = {}));
+    ArrayBase.prototype.empty = function () {
+        return this._array.length === 0;
+    };
+
+    /**
+    * Returns the item at the given array index.
+    *
+    * @param index The integer index of the desired item.
+    */
+    ArrayBase.prototype.itemAt = function (index) {
+        return this._array[index];
+    };
+
+    /**
+    * Removes and returns the item at the given index.
+    *
+    * @param index The integer index of the desired item.
+    */
+    ArrayBase.prototype.takeAt = function (index) {
+        return this._array.splice(index, 1)[0];
+    };
+
+    /**
+    * Clear the internal contents of array.
+    */
+    ArrayBase.prototype.clear = function () {
+        this._array = [];
+    };
+
+    /**
+    * Swap this array's contents with another array.
+    *
+    * @param other The array base to use for the swap.
+    */
+    ArrayBase.prototype.swap = function (other) {
+        var array = this._array;
+        this._array = other._array;
+        other._array = array;
+    };
+
+    /**
+    * Returns an iterator over the array of items.
+    */
+    ArrayBase.prototype.__iter__ = function () {
+        return iter(this._array);
+    };
+
+    /**
+    * Returns a reverse iterator over the array of items.
+    */
+    ArrayBase.prototype.__reversed__ = function () {
+        return reversed(this._array);
+    };
+    return ArrayBase;
+})();
+export { ArrayBase };
+
 /*-----------------------------------------------------------------------------
 | Copyright (c) 2014, Nucleic Development Team.
 |
@@ -163,380 +323,201 @@ var tsu;
 |
 | The full license is in the file COPYING.txt, distributed with this software.
 |----------------------------------------------------------------------------*/
-/// <reference path="iterator.ts"/>
-/// <reference path="utility.ts"/>
-var tsu;
-(function (tsu) {
-    /**
-    * Perform a lower bound search on a sorted array.
-    *
-    * @param array The array of sorted items to search.
-    * @param value The value to located in the array.
-    * @param compare The value comparison function.
-    * @returns The index of the first element in the array which
-    *          compares greater than or equal to the given value.
-    */
-    function lowerBound(array, value, compare) {
-        var begin = 0;
-        var n = array.length;
-        var half;
-        var middle;
-        while (n > 0) {
-            half = n >> 1;
-            middle = begin + half;
-            if (compare(array[middle], value) < 0) {
-                begin = middle + 1;
-                n -= half + 1;
-            } else {
-                n = half;
-            }
-        }
-        return begin;
-    }
-    tsu.lowerBound = lowerBound;
-
-    /**
-    * Perform a binary search on a sorted array.
-    *
-    * @param array The array of sorted items to search.
-    * @param value The value to located in the array.
-    * @param compare The value comparison function.
-    * @returns The index of the found item, or -1.
-    */
-    function binarySearch(array, value, compare) {
-        var index = lowerBound(array, value, compare);
-        if (index === array.length) {
-            return -1;
-        }
-        var item = array[index];
-        if (compare(item, value) !== 0) {
-            return -1;
-        }
-        return index;
-    }
-    tsu.binarySearch = binarySearch;
-
-    /**
-    * Perform a binary find on a sorted array.
-    *
-    * @param array The array of sorted items to search.
-    * @param value The value to located in the array.
-    * @param compare The value comparison function.
-    * @returns The found item in the array, or undefined.
-    */
-    function binaryFind(array, value, compare) {
-        var index = lowerBound(array, value, compare);
-        if (index === array.length) {
-            return undefined;
-        }
-        var item = array[index];
-        if (compare(item, value) !== 0) {
-            return undefined;
-        }
-        return item;
-    }
-    tsu.binaryFind = binaryFind;
-
-})(tsu || (tsu = {}));
-/*-----------------------------------------------------------------------------
-| Copyright (c) 2014, Nucleic Development Team.
-|
-| Distributed under the terms of the Modified BSD License.
-|
-| The full license is in the file COPYING.txt, distributed with this software.
-|----------------------------------------------------------------------------*/
-/// <reference path="iterator.ts"/>
-var tsu;
-(function (tsu) {
-    /**
-    * A base class for implementing array-based data structures.
-    *
-    * @class
-    */
-    var ArrayBase = (function () {
-        function ArrayBase() {
-            /*
-            * The internal data array.
-            *
-            * @protected
-            */
-            this._array = [];
-        }
-        /**
-        * Returns the number of items in the array.
-        */
-        ArrayBase.prototype.size = function () {
-            return this._array.length;
-        };
-
-        /**
-        * Returns true if the array is empty.
-        */
-        ArrayBase.prototype.empty = function () {
-            return this._array.length === 0;
-        };
-
-        /**
-        * Returns the item at the given array index.
-        *
-        * @param index The integer index of the desired item.
-        */
-        ArrayBase.prototype.itemAt = function (index) {
-            return this._array[index];
-        };
-
-        /**
-        * Removes and returns the item at the given index.
-        *
-        * @param index The integer index of the desired item.
-        */
-        ArrayBase.prototype.takeAt = function (index) {
-            return this._array.splice(index, 1)[0];
-        };
-
-        /**
-        * Clear the internal contents of array.
-        */
-        ArrayBase.prototype.clear = function () {
-            this._array = [];
-        };
-
-        /**
-        * Swap this array's contents with another array.
-        *
-        * @param other The array base to use for the swap.
-        */
-        ArrayBase.prototype.swap = function (other) {
-            var array = this._array;
-            this._array = other._array;
-            other._array = array;
-        };
-
-        /**
-        * Returns an iterator over the array of items.
-        */
-        ArrayBase.prototype.__iter__ = function () {
-            return tsu.iter(this._array);
-        };
-
-        /**
-        * Returns a reverse iterator over the array of items.
-        */
-        ArrayBase.prototype.__reversed__ = function () {
-            return tsu.reversed(this._array);
-        };
-        return ArrayBase;
-    })();
-    tsu.ArrayBase = ArrayBase;
-})(tsu || (tsu = {}));
-/*-----------------------------------------------------------------------------
-| Copyright (c) 2014, Nucleic Development Team.
-|
-| Distributed under the terms of the Modified BSD License.
-|
-| The full license is in the file COPYING.txt, distributed with this software.
-|----------------------------------------------------------------------------*/
-var __extends = this.__extends || function (d, b) {
-    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
-    function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+var __extends = (this && this.__extends) || function (d, b) {
+for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+function __() { this.constructor = d; }
+__.prototype = b.prototype;
+d.prototype = new __();
 };
-/// <reference path="algorithm.ts"/>
-/// <reference path="array_base.ts"/>
-/// <reference path="iterator.ts"/>
-/// <reference path="utility.ts"/>
-var tsu;
-(function (tsu) {
+
+/**
+* A mapping container build on a sorted array.
+*
+* @class
+*/
+var AssociativeArray = (function (_super) {
+    __extends(AssociativeArray, _super);
     /**
-    * A mapping container build on a sorted array.
+    * Construct a new AssociativeArray.
     *
-    * @class
+    * @param compare The key comparison function.
     */
-    var AssociativeArray = (function (_super) {
-        __extends(AssociativeArray, _super);
-        /**
-        * Construct a new AssociativeArray.
-        *
-        * @param compare The key comparison function.
-        */
-        function AssociativeArray(compare) {
-            _super.call(this);
-            this._compare = compare;
-            this._wrapped = wrapCompare(compare);
-        }
-        /**
-        * Returns the key comparison function used by this array.
-        */
-        AssociativeArray.prototype.comparitor = function () {
-            return this._compare;
-        };
-
-        /**
-        * Return the array index of the given key, or -1.
-        *
-        * @param key The key to locate in the array.
-        */
-        AssociativeArray.prototype.indexOf = function (key) {
-            return tsu.binarySearch(this._array, key, this._wrapped);
-        };
-
-        /**
-        * Returns true if the key is in the array, false otherwise.
-        *
-        * @param key The key to locate in the array.
-        */
-        AssociativeArray.prototype.contains = function (key) {
-            return tsu.binarySearch(this._array, key, this._wrapped) >= 0;
-        };
-
-        /**
-        * Returns the pair associated with the given key, or undefined.
-        *
-        * @param key The key to locate in the array.
-        */
-        AssociativeArray.prototype.find = function (key) {
-            return tsu.binaryFind(this._array, key, this._wrapped);
-        };
-
-        /**
-        * Returns the pair associated with the key if it exists.
-        *
-        * If the key does not exist, a new pair will be created and
-        * inserted using the value created by the given factory.
-        *
-        * @param key The key to locate in the array.
-        * @param factory The function which creates the default value.
-        */
-        AssociativeArray.prototype.setDefault = function (key, factory) {
-            var array = this._array;
-            var index = tsu.lowerBound(array, key, this._wrapped);
-            if (index === array.length) {
-                var pair = new tsu.Pair(key, factory());
-                array.push(pair);
-                return pair;
-            }
-            var currPair = array[index];
-            if (this._compare(currPair.first, key) !== 0) {
-                var pair = new tsu.Pair(key, factory());
-                array.splice(index, 0, pair);
-                return pair;
-            }
-            return currPair;
-        };
-
-        /**
-        * Insert the pair into the array and return the pair.
-        *
-        * This will overwrite any existing entry in the array.
-        *
-        * @param key The key portion of the pair.
-        * @param value The value portion of the pair.
-        */
-        AssociativeArray.prototype.insert = function (key, value) {
-            var array = this._array;
-            var index = tsu.lowerBound(array, key, this._wrapped);
-            if (index === array.length) {
-                var pair = new tsu.Pair(key, value);
-                array.push(pair);
-                return pair;
-            }
-            var currPair = array[index];
-            if (this._compare(currPair.first, key) !== 0) {
-                var pair = new tsu.Pair(key, value);
-                array.splice(index, 0, pair);
-                return pair;
-            }
-            currPair.second = value;
-            return currPair;
-        };
-
-        AssociativeArray.prototype.update = function (object) {
-            var _this = this;
-            if (object instanceof AssociativeArray) {
-                var obj = object;
-                this._array = merge(this._array, obj._array, this._compare);
-            } else {
-                tsu.forEach(object, function (pair) {
-                    _this.insert(pair.first, pair.second);
-                });
-            }
-        };
-
-        /**
-        * Removes and returns the pair for the given key, or undefined.
-        *
-        * @param key The key to remove from the map.
-        */
-        AssociativeArray.prototype.erase = function (key) {
-            var array = this._array;
-            var index = tsu.binarySearch(array, key, this._wrapped);
-            if (index < 0) {
-                return undefined;
-            }
-            return array.splice(index, 1)[0];
-        };
-
-        /**
-        * Create a copy of this associative array.
-        */
-        AssociativeArray.prototype.copy = function () {
-            var theCopy = new AssociativeArray(this._compare);
-            var copyArray = theCopy._array;
-            var thisArray = this._array;
-            for (var i = 0, n = thisArray.length; i < n; ++i) {
-                copyArray.push(thisArray[i].copy());
-            }
-            return theCopy;
-        };
-        return AssociativeArray;
-    })(tsu.ArrayBase);
-    tsu.AssociativeArray = AssociativeArray;
-
-    /**
-    * An internal which wraps a comparison key function.
-    */
-    function wrapCompare(cmp) {
-        return function (pair, value) {
-            return cmp(pair.first, value);
-        };
+    function AssociativeArray(compare) {
+        _super.call(this);
+        this._compare = compare;
+        this._wrapped = wrapCompare(compare);
     }
+    /**
+    * Returns the key comparison function used by this array.
+    */
+    AssociativeArray.prototype.comparitor = function () {
+        return this._compare;
+    };
 
     /**
-    * An internal function which merges two ordered pair arrays.
+    * Return the array index of the given key, or -1.
+    *
+    * @param key The key to locate in the array.
     */
-    function merge(first, second, compare) {
-        var i = 0, j = 0;
-        var len1 = first.length;
-        var len2 = second.length;
-        var merged = [];
-        while (i < len1 && j < len2) {
-            var a = first[i];
-            var b = second[j];
-            var v = compare(a.first, b.first);
-            if (v < 0) {
-                merged.push(a.copy());
-                ++i;
-            } else if (v > 0) {
-                merged.push(b.copy());
-                ++j;
-            } else {
-                merged.push(b.copy());
-                ++i;
-                ++j;
-            }
+    AssociativeArray.prototype.indexOf = function (key) {
+        return binarySearch(this._array, key, this._wrapped);
+    };
+
+    /**
+    * Returns true if the key is in the array, false otherwise.
+    *
+    * @param key The key to locate in the array.
+    */
+    AssociativeArray.prototype.contains = function (key) {
+        return binarySearch(this._array, key, this._wrapped) >= 0;
+    };
+
+    /**
+    * Returns the pair associated with the given key, or undefined.
+    *
+    * @param key The key to locate in the array.
+    */
+    AssociativeArray.prototype.find = function (key) {
+        return binaryFind(this._array, key, this._wrapped);
+    };
+
+    /**
+    * Returns the pair associated with the key if it exists.
+    *
+    * If the key does not exist, a new pair will be created and
+    * inserted using the value created by the given factory.
+    *
+    * @param key The key to locate in the array.
+    * @param factory The function which creates the default value.
+    */
+    AssociativeArray.prototype.setDefault = function (key, factory) {
+        var array = this._array;
+        var index = lowerBound(array, key, this._wrapped);
+        if (index === array.length) {
+            var pair = new Pair(key, factory());
+            array.push(pair);
+            return pair;
         }
-        while (i < len1) {
-            merged.push(first[i].copy());
+        var currPair = array[index];
+        if (this._compare(currPair.first, key) !== 0) {
+            var pair = new Pair(key, factory());
+            array.splice(index, 0, pair);
+            return pair;
+        }
+        return currPair;
+    };
+
+    /**
+    * Insert the pair into the array and return the pair.
+    *
+    * This will overwrite any existing entry in the array.
+    *
+    * @param key The key portion of the pair.
+    * @param value The value portion of the pair.
+    */
+    AssociativeArray.prototype.insert = function (key, value) {
+        var array = this._array;
+        var index = lowerBound(array, key, this._wrapped);
+        if (index === array.length) {
+            var pair = new Pair(key, value);
+            array.push(pair);
+            return pair;
+        }
+        var currPair = array[index];
+        if (this._compare(currPair.first, key) !== 0) {
+            var pair = new Pair(key, value);
+            array.splice(index, 0, pair);
+            return pair;
+        }
+        currPair.second = value;
+        return currPair;
+    };
+
+    AssociativeArray.prototype.update = function (object) {
+        var _this = this;
+        if (object instanceof AssociativeArray) {
+            var obj = object;
+            this._array = merge(this._array, obj._array, this._compare);
+        } else {
+            forEach(object, function (pair) {
+                _this.insert(pair.first, pair.second);
+            });
+        }
+    };
+
+    /**
+    * Removes and returns the pair for the given key, or undefined.
+    *
+    * @param key The key to remove from the map.
+    */
+    AssociativeArray.prototype.erase = function (key) {
+        var array = this._array;
+        var index = binarySearch(array, key, this._wrapped);
+        if (index < 0) {
+            return undefined;
+        }
+        return array.splice(index, 1)[0];
+    };
+
+    /**
+    * Create a copy of this associative array.
+    */
+    AssociativeArray.prototype.copy = function () {
+        var theCopy = new AssociativeArray(this._compare);
+        var copyArray = theCopy._array;
+        var thisArray = this._array;
+        for (var i = 0, n = thisArray.length; i < n; ++i) {
+            copyArray.push(thisArray[i].copy());
+        }
+        return theCopy;
+    };
+    return AssociativeArray;
+})(ArrayBase);
+export { AssociativeArray };
+
+/**
+* An internal which wraps a comparison key function.
+*/
+function wrapCompare(cmp) {
+    return function (pair, value) {
+        return cmp(pair.first, value);
+    };
+}
+
+/**
+* An internal function which merges two ordered pair arrays.
+*/
+function merge(first, second, compare) {
+    var i = 0, j = 0;
+    var len1 = first.length;
+    var len2 = second.length;
+    var merged = [];
+    while (i < len1 && j < len2) {
+        var a = first[i];
+        var b = second[j];
+        var v = compare(a.first, b.first);
+        if (v < 0) {
+            merged.push(a.copy());
             ++i;
-        }
-        while (j < len2) {
-            merged.push(second[j].copy());
+        } else if (v > 0) {
+            merged.push(b.copy());
+            ++j;
+        } else {
+            merged.push(b.copy());
+            ++i;
             ++j;
         }
-        return merged;
     }
-})(tsu || (tsu = {}));
+    while (i < len1) {
+        merged.push(first[i].copy());
+        ++i;
+    }
+    while (j < len2) {
+        merged.push(second[j].copy());
+        ++j;
+    }
+    return merged;
+}
 /*-----------------------------------------------------------------------------
 | Copyright (c) 2014, Nucleic Development Team.
 |

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "target": "ES5",
+        "module": "es2015",
+        //"strict": true, // aah: currently fails to build in strict mode, as previous build only specified noImplicitAny
+        "noImplicitAny": true,
+        "outDir": "es",
+        "declaration": true
+    },
+    "include": [ "src/*.ts" ]
+}


### PR DESCRIPTION
Note: this branches from my other PR, es6-modules.  If you decide not to use that, I can re-submit against master.

This PR replaces tsu.AssociativeArray with a basic indexed map implementation, so that lookups run in O(1) rather than O(log n) time.  The new implementation recreates the parts of the tsu.AssociativeArray interface that were used by kiwi.js, requiring no code changes to consumers.  The dependency on the internal tsu library is dropped.

This results in a 1.1x improvement to the creation benchmark and a 3.8x improvement to the update benchmark.  It also removes 370 lines from the package.

```sh
silence:kiwi.js aah$ git checkout es6-modules
Switched to branch 'es6-modules'
silence:kiwi.js aah$ node -v
v10.9.0
silence:kiwi.js aah$ npm run bench

> kiwi.js@1.0.2 bench /Users/aah/Dropbox/Tech Projects/kiwi.js
> node bench/main.js

----- Running creation benchmark...
Cassowary.js x 3,073 ops/sec ±1.07% (83 runs sampled)
kiwi x 19,942 ops/sec ±0.45% (83 runs sampled)
kiwi new API x 18,855 ops/sec ±0.71% (90 runs sampled)
Fastest is kiwi (± 6.49x faster)
----- Running solving benchmark...
Cassowary.js x 193,467 ops/sec ±0.46% (88 runs sampled)
kiwi x 140,130 ops/sec ±0.58% (90 runs sampled)
Fastest is Cassowary.js (± 1.38x faster)
silence:kiwi.js aah$ git checkout indexed-map
Switched to branch 'indexed-map'
silence:kiwi.js aah$ npm run bench

> kiwi.js@1.0.2 bench /Users/aah/Dropbox/Tech Projects/kiwi.js
> node bench/main.js

----- Running creation benchmark...
Cassowary.js x 3,101 ops/sec ±1.05% (83 runs sampled)
kiwi x 22,242 ops/sec ±0.41% (90 runs sampled)
kiwi new API x 20,867 ops/sec ±0.75% (86 runs sampled)
Fastest is kiwi (± 7.17x faster)
----- Running solving benchmark...
Cassowary.js x 194,443 ops/sec ±0.50% (86 runs sampled)
kiwi x 536,907 ops/sec ±0.33% (94 runs sampled)
Fastest is kiwi (± 2.76x faster)
```

One behavioral change which I do not think is significant but which bears mentioning is that tsu.AssociativeArray kept its backing array sorted in the order of the keys' .id() property.  The indexed map does not, so the order in which items are iterated will be different.  I don't believe this is significant, but I'm still digesting the cassowary algorithm.  All tests pass.